### PR TITLE
Add installation instructions for Brunch

### DIFF
--- a/source/docs/installation.blade.md
+++ b/source/docs/installation.blade.md
@@ -209,3 +209,22 @@ mix.sass('resources/assets/sass/app.scss', 'public/css')
 ```
 
 For more information on what this feature does and the implications of disabling it, [see the Laravel Mix documentation](https://github.com/JeffreyWay/laravel-mix/blob/master/docs/css-preprocessors.md#css-url-rewriting).
+
+#### Brunch
+
+Add `tailwindcss` to the list of processors you pass to [postcss-brunch](https://github.com/brunch/postcss-brunch), passing the path to your config file:
+
+```js
+exports.config = {
+  // ..
+  plugins: {
+    // ...
+    postcss: {
+      processors: [
+        require('tailwindcss')('./tailwind.js')
+      ]
+    }
+    // ...
+  }
+};
+```


### PR DESCRIPTION
The [Phoenix web framework](http://phoenixframework.org/) uses [Brunch](https://brunch.io/) by default for asset processing so adding these instructions should prove useful for folks wanting to get going with Tailwind in an out-of-the-box Phoenix project (as well as for those simply using Brunch of their own accord).