### PR TITLE
Add .cursor-default

### DIFF
--- a/source/docs/cursor.blade.md
+++ b/source/docs/cursor.blade.md
@@ -19,6 +19,11 @@ features:
       "Set the mouse cursor to the default browser behavior.",
     ],
     [
+      '.cursor-default',
+      'cursor: default;',
+      "Set the mouse cursor to the platform default. Typically an arrow.",
+    ],
+    [
       '.cursor-pointer',
       'cursor: pointer;',
       "Set the mouse cursor to a pointer and indicate a link.",


### PR DESCRIPTION
Adds [`.cursor-default`](https://github.com/tailwindcss/tailwindcss/blob/master/src/generators/cursor.js#L6) to the cursor documentation.