### PR TITLE
Disable jump to top by dummy links

### DIFF
--- a/source/_assets/js/app.js
+++ b/source/_assets/js/app.js
@@ -21,6 +21,13 @@ Mousetrap.bind('/', function (e) {
   document.getElementById('docsearch').focus()
 })
 
+// Disable jump to top by dummy links (<a href="#">Link</a>)
+document.querySelectorAll('.markdown a[href="#"]').forEach(function (i) {
+  i.addEventListener('click', function (e) {
+    e.preventDefault()
+  })
+})
+
 ;(function () {
   var s = document.createElement('script')
   s.setAttribute('async', '')


### PR DESCRIPTION
Prevents the page from jumping to the top if a user clicks on a [dummy link in the examples](https://tailwindcss.com/docs/examples/navigation).