### PR TITLE
Document laravel-mix-tailwind plugin

### DIFF
--- a/source/docs/installation.blade.md
+++ b/source/docs/installation.blade.md
@@ -178,40 +178,16 @@ gulp.task('css', function () {
 
 #### Laravel Mix
 
-If you're writing your project in plain CSS, use Mix's `postCss` method to process your CSS. Include `tailwindcss` as a plugin and pass the path to your config file:
+
+If you're using Laravel Mix 2.1 or later, just `npm install laravel-mix-tailwind` or `yarn add laravel-mix-tailwind` and add the plugin to your webpack.mix.js file:
 
 ```js
-var tailwindcss = require('tailwindcss');
+require('laravel-mix-tailwind');
 
-mix.postCss('resources/assets/css/main.css', 'public/css', [
-  tailwindcss('./path/to/your/tailwind-config.js'),
-]);
+mix.tailwind();
 ```
 
-If you're using a preprocessor, use the `options` method to add `tailwindcss` as a PostCSS plugin:
-
-```js
-var tailwindcss = require('tailwindcss');
-
-mix.less('resources/assets/less/app.less', 'public/css')
-  .options({
-    postCss: [
-      tailwindcss('./path/to/your/tailwind-config.js'),
-    ]
-  });
-```
-
-**Note for Sass users:** Due to [an unresolved issue](https://github.com/bholloway/resolve-url-loader/issues/28) with one of Mix's dependencies, to use Sass with Tailwind you'll need to disable `processCssUrls`:
-
-```js
-var tailwindcss = require('tailwindcss');
-
-mix.sass('resources/assets/sass/app.scss', 'public/css')
-  .options({
-    processCssUrls: false,
-    postCss: [ tailwindcss('./path/to/your/tailwind-config.js') ],
-  });
-```
+**Note for Sass users:** Due to [an unresolved issue](https://github.com/bholloway/resolve-url-loader/issues/28) with one of Mix's dependencies, the plugin will set `Config.processCssUrls = false`.
 
 For more information on what this feature does and the implications of disabling it, [see the Laravel Mix documentation](https://github.com/JeffreyWay/laravel-mix/blob/master/docs/css-preprocessors.md#css-url-rewriting).
 


### PR DESCRIPTION
For users of Laravel Mix 2.1, there's a [tailwind plugin](https://github.com/JeffreyWay/laravel-mix-tailwind) available. It simplifies the setup and automatically cares for disabling `Config.processCssUrls` when sass is used. This is now reflected in the documentation.Thanks, @JeffreyWay. 