### PR TITLE
Add `Output` column to color-related tables

### DIFF
--- a/source/_partials/class-color-table.blade.php
+++ b/source/_partials/class-color-table.blade.php
@@ -1,0 +1,34 @@
+@php
+  $scroll = isset($scroll) ? $scroll : true;
+  $scroll = (count($rows) > 12 && ($scroll !== false));
+  // $scroll = false;
+@endphp
+
+<h2 style="visibility: hidden; font-size: 0; margin: 0;">Class reference</h2>
+<div class="border-t border-b border-grey-light overflow-hidden relative">
+  <div class="{{ $scroll ? 'max-h-sm pb-10' : '' }} overflow-y-auto">
+    <table class="w-full text-left table-collapse">
+      <thead>
+        <tr>
+          <th class="text-sm font-semibold text-grey-darker p-2 bg-grey-lightest">Class</th>
+          <th class="text-sm font-semibold text-grey-darker p-2 bg-grey-lightest">Properties</th>
+          <th class="text-sm font-semibold text-grey-darker p-2 bg-grey-lightest">Output</th>
+        </tr>
+      </thead>
+      <tbody class="align-baseline">
+        @foreach ($rows as $row)
+        <tr>
+          <td class="p-2 border-t {{ $loop->first ? 'border-grey-light' : 'border-grey-lighter' }} font-mono text-xs text-purple-dark whitespace-no-wrap">{!! $row[0] !!}</td>
+          <td class="p-2 border-t {{ $loop->first ? 'border-grey-light' : 'border-grey-lighter' }} font-mono text-xs text-blue-dark whitespace-pre">{!! $row[1] !!}</td>
+          <td class="p-2 border-t {{ $loop->first ? 'border-grey-light' : 'border-grey-lighter' }} font-mono text-xs text-blue-dark whitespace-pre {!! $row[2] !!}"></td>
+        </tr>
+        @endforeach
+      </tbody>
+    </table>
+  </div>
+  @if ($scroll)
+  <div class="bg-white opacity-50 text-center absolute pin-b pin-x py-2 flex justify-center shadow-md-light">
+      <svg class="h-6 w-6 fill-current text-grey-dark" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
+  </div>
+  @endif
+</div>

--- a/source/docs/background-color.blade.md
+++ b/source/docs/background-color.blade.md
@@ -11,15 +11,17 @@ features:
 
 @include('_partials.work-in-progress')
 
-@include('_partials.class-table', [
+@include('_partials.class-color-table', [
   'rows' => $page->config['colors']->map(function ($value, $name) {
     $class = ".bg-{$name}";
     $code = "background-color: {$value};";
+    $output = "bg-{$name} text-transparent";
     $color = implode(' ', array_reverse(explode('-', $name)));
     $description = "Set the background color of an element to {$color}.";
     return [
       $class,
       $code,
+      $output,
       $description,
     ];
   })->values()->all()

--- a/source/docs/text-color.blade.md
+++ b/source/docs/text-color.blade.md
@@ -11,15 +11,17 @@ features:
 
 @include('_partials.work-in-progress')
 
-@include('_partials.class-table', [
+@include('_partials.class-color-table', [
   'rows' => $page->config['colors']->map(function ($value, $name) {
     $class = ".text-{$name}";
     $code = "color: {$value};";
+    $output = "bg-{$name}";
     $color = implode(' ', array_reverse(explode('-', $name)));
     $description = "Set the text color of an element to {$color}.";
     return [
       $class,
       $code,
+      $output,
       $description,
     ];
   })->values()->all()


### PR DESCRIPTION
As I mentioned in #9, I think that an `Output` column on tables meant to document colors would be really useful.

Even if in the meanwhile I found out (how blind I was) that there's an [entire page dedicated to colors](https://tailwindcss.com/docs/colors/), I still advocate my cause: why should I open two tabs just to check out such a simple and straightforward information?