### PR TITLE
Fixing classname extraction in templated strings

### DIFF
--- a/source/docs/controlling-file-size.blade.md
+++ b/source/docs/controlling-file-size.blade.md
@@ -165,7 +165,7 @@ let PurgecssPlugin = require("purgecss-webpack-plugin");
 // https://github.com/FullHuman/purgecss#extractor
 class TailwindExtractor {
   static extract(content) {
-    return (content.match(/[A-z0-9-:\/]+/g) || []).map(m => m.replace("`", ""));
+    return content.match(/[A-Za-z0-9-:\/]+/g) || [];
   }
 }
 

--- a/source/docs/controlling-file-size.blade.md
+++ b/source/docs/controlling-file-size.blade.md
@@ -165,7 +165,7 @@ let PurgecssPlugin = require("purgecss-webpack-plugin");
 // https://github.com/FullHuman/purgecss#extractor
 class TailwindExtractor {
   static extract(content) {
-    return content.match(/[A-z0-9-:\/]+/g) || [];
+    return (content.match(/[A-z0-9-:\/]+/g) || []).map(m => m.replace("`", ""));
   }
 }
 


### PR DESCRIPTION
The full case described here: https://github.com/FullHuman/purgecss/issues/75

In result was not a purgecss issue but extractor being too eager and matching class names together with `.