### PR TITLE
updated version from 0.5.2 to 0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "postcss-cssnext": "^3.0.2",
     "prismjs": "^1.8.3",
     "stylefmt": "^6.0.0",
-    "tailwindcss": "0.5.2",
+    "tailwindcss": "0.5.3",
     "vue": "^2.5.2",
     "webpack-watch": "^0.2.0",
     "yargs": "^10.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7415,9 +7415,9 @@ table@^4.0.1:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
-tailwindcss@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-0.5.2.tgz#eded994f26ee9715e2bb13ba82ed087637994e15"
+tailwindcss@0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-0.5.3.tgz#5444f85ab5e68a37c2bf13bc4ac097a7ee05321d"
   dependencies:
     commander "^2.11.0"
     fs-extra "^4.0.2"


### PR DESCRIPTION
The version displayed on the website is still 0.5.2 and not the current version 0.5.3. So I updated the required version in package.json as well as in the yarn.lock file