### PR TITLE
Enable more variants by default

### DIFF
--- a/source/docs/background-color.blade.md
+++ b/source/docs/background-color.blade.md
@@ -51,5 +51,6 @@ Hover utilities can also be combined with responsive utilities by adding the res
     'variants' => [
         'responsive',
         'hover',
+        'focus'
     ],
 ])

--- a/source/docs/border-color.blade.md
+++ b/source/docs/border-color.blade.md
@@ -51,5 +51,6 @@ Hover utilities can also be combined with responsive utilities by adding the res
     'variants' => [
         'responsive',
         'hover',
+        'focus',
     ],
 ])

--- a/source/docs/font-weight.blade.md
+++ b/source/docs/font-weight.blade.md
@@ -87,5 +87,6 @@ Hover utilities can also be combined with responsive utilities by adding the res
     'variants' => [
         'responsive',
         'hover',
+        'focus',
     ],
 ])

--- a/source/docs/shadows.blade.md
+++ b/source/docs/shadows.blade.md
@@ -139,5 +139,7 @@ If a `default` shadow is provided, it will be used for the non-suffixed `.shadow
     ],
     'variants' => [
         'responsive',
+        'hover',
+        'focus',
     ],
 ])

--- a/source/docs/text-color.blade.md
+++ b/source/docs/text-color.blade.md
@@ -51,5 +51,6 @@ Hover utilities can also be combined with responsive utilities by adding the res
     'variants' => [
         'responsive',
         'hover',
+        'focus',
     ],
 ])

--- a/source/docs/text-style.blade.md
+++ b/source/docs/text-style.blade.md
@@ -95,5 +95,6 @@ Hover utilities can also be combined with responsive utilities by adding the res
     'variants' => [
         'responsive',
         'hover',
+        'focus',
     ],
 ])


### PR DESCRIPTION
Bring consistency with tailwindcss/tailwindcss#498

BTW: When checking all docs, I across the fact that there aren't any docs for `borderCollapse` & `outline`