### PR TITLE
Enable more variants by default

### DIFF
--- a/source/docs/background-color.blade.md
+++ b/source/docs/background-color.blade.md
@@ -51,5 +51,6 @@ Hover utilities can also be combined with responsive utilities by adding the res
     'variants' => [
         'responsive',
         'hover',
+        'focus'
     ],
 ])

--- a/source/docs/border-color.blade.md
+++ b/source/docs/border-color.blade.md
@@ -51,5 +51,6 @@ Hover utilities can also be combined with responsive utilities by adding the res
     'variants' => [
         'responsive',
         'hover',
+        'focus',
     ],
 ])

--- a/source/docs/font-weight.blade.md
+++ b/source/docs/font-weight.blade.md
@@ -87,5 +87,6 @@ Hover utilities can also be combined with responsive utilities by adding the res
     'variants' => [
         'responsive',
         'hover',
+        'focus',
     ],
 ])

--- a/source/docs/shadows.blade.md
+++ b/source/docs/shadows.blade.md
@@ -139,5 +139,7 @@ If a `default` shadow is provided, it will be used for the non-suffixed `.shadow
     ],
     'variants' => [
         'responsive',
+        'hover',
+        'focus',
     ],
 ])

--- a/source/docs/state-variants.blade.md
+++ b/source/docs/state-variants.blade.md
@@ -29,7 +29,7 @@ Add the `hover:` prefix to only apply a utility on hover.
       <svg class="fill-current h-6 w-6 text-white opacity-75 mr-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M10 20C4.477 20 0 15.523 0 10S4.477 0 10 0s10 4.477 10 10-4.477 10-10 10zm0-2c4.418 0 8-3.582 8-8s-3.582-8-8-8-8 3.582-8 8 3.582 8 8 8zm-.5-5h1c.276 0 .5.224.5.5v1c0 .276-.224.5-.5.5h-1c-.276 0-.5-.224-.5-.5v-1c0-.276.224-.5.5-.5zm0-8h1c.276 0 .5.224.5.5V8l-.5 3-1 .5L9 8V5.5c0-.276.224-.5.5-.5z"/></svg>
     </div>
     <div>
-      <p class="leading-tight mb-2"><strong class="font-bold">By default, hover variants are only generated for background color, border color, font weight, text color, and text style utilities.</strong></p>
+      <p class="leading-tight mb-2"><strong class="font-bold">By default, hover variants are only generated for background color, border color, font weight, shadow, text color, and text style utilities.</strong></p>
       <p>You can customize this in the <a href="/docs/configuration#modules" class="underline">modules section</a> of your configuration file.</p>
     </div>
   </div>
@@ -56,7 +56,7 @@ Add the `focus:` prefix to only apply a utility on focus.
       <svg class="fill-current h-6 w-6 text-white opacity-75 mr-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M10 20C4.477 20 0 15.523 0 10S4.477 0 10 0s10 4.477 10 10-4.477 10-10 10zm0-2c4.418 0 8-3.582 8-8s-3.582-8-8-8-8 3.582-8 8 3.582 8 8 8zm-.5-5h1c.276 0 .5.224.5.5v1c0 .276-.224.5-.5.5h-1c-.276 0-.5-.224-.5-.5v-1c0-.276.224-.5.5-.5zm0-8h1c.276 0 .5.224.5.5V8l-.5 3-1 .5L9 8V5.5c0-.276.224-.5.5-.5z"/></svg>
     </div>
     <div>
-      <p class="leading-tight mb-2"><strong class="font-bold">By default, focus variants are not generated for any utilities.</strong></p>
+      <p class="leading-tight mb-2"><strong class="font-bold">By default, focus variants are only generated for background color, border color, font weight, outline, shadow, text color, and text style utilities.</strong></p>
       <p>You can customize this in the <a href="/docs/configuration#modules" class="underline">modules section</a> of your configuration file.</p>
     </div>
   </div>

--- a/source/docs/text-color.blade.md
+++ b/source/docs/text-color.blade.md
@@ -51,5 +51,6 @@ Hover utilities can also be combined with responsive utilities by adding the res
     'variants' => [
         'responsive',
         'hover',
+        'focus',
     ],
 ])

--- a/source/docs/text-style.blade.md
+++ b/source/docs/text-style.blade.md
@@ -95,5 +95,6 @@ Hover utilities can also be combined with responsive utilities by adding the res
     'variants' => [
         'responsive',
         'hover',
+        'focus',
     ],
 ])


### PR DESCRIPTION
Bring consistency with tailwindcss/tailwindcss#498

BTW: When checking all docs, I across the fact that there aren't any docs for `borderCollapse` & `outline`