### PR TITLE
Fix typo in space 20 size

### DIFF
--- a/source/docs/spacing.blade.md
+++ b/source/docs/spacing.blade.md
@@ -45,7 +45,7 @@ For example, `.pt-2` would add `.5rem` of padding to the top of the element, `.m
     <div><code class="inline-block my-1 mr-1 px-2 py-1 font-mono border rounded">10</code> 2.5rem</div>
     <div><code class="inline-block my-1 mr-1 px-2 py-1 font-mono border rounded">12</code> 3rem</div>
     <div><code class="inline-block my-1 mr-1 px-2 py-1 font-mono border rounded">16</code> 4rem</div>
-    <div><code class="inline-block my-1 mr-1 px-2 py-1 font-mono border rounded">20</code> 4rem</div>
+    <div><code class="inline-block my-1 mr-1 px-2 py-1 font-mono border rounded">20</code> 5rem</div>
     <div><code class="inline-block my-1 mr-1 px-2 py-1 font-mono border rounded">24</code> 6rem</div>
     <div><code class="inline-block my-1 mr-1 px-2 py-1 font-mono border rounded">32</code> 8rem</div>
     <div><code class="inline-block my-1 mr-1 px-1 py-1 font-mono border rounded">px</code> 1px</div>


### PR DESCRIPTION
I found this tiny typo in the spacing page.