### PR TITLE
Updated shadow-outline from 0.6.1 fix

### DIFF
--- a/source/docs/shadows.blade.md
+++ b/source/docs/shadows.blade.md
@@ -33,7 +33,7 @@ features:
     ],
     [
       '.shadow-outline',
-      "box-shadow: 2px solid rgba(52,144,220,0.5);",
+      "box-shadow: 0 0 0 3px rgba(52,144,220,0.5);",
       "Apply a small inner box shadow to an element.",
     ],
     [
@@ -149,6 +149,7 @@ If a `default` shadow is provided, it will be used for the non-suffixed `.shadow
 - 'md': '0 4px 8px 0 rgba(0,0,0,0.12), 0 2px 4px 0 rgba(0,0,0,0.08)',
 - 'lg': '0 15px 30px 0 rgba(0,0,0,0.11), 0 5px 15px 0 rgba(0,0,0,0.08)',
 - 'inner': 'inset 0 2px 4px 0 rgba(0,0,0,0.06)',
+- 'outline': '0 0 0 3px rgba(52,144,220,0.5)',
 + '1': '0 2px 4px rgba(0,0,0,0.05)',
 + '2': '0 4px 8px rgba(0,0,0,0.1)',
 + '3': '0 8px 16px rgba(0,0,0,0.15)',


### PR DESCRIPTION
The shadow-outline value matches the current 0.6.1 default value. Also added outline to the customizing section.