### PR TITLE
Add new Laravel JS structure to the PurgeCSS docs

### DIFF
--- a/source/docs/controlling-file-size.blade.md
+++ b/source/docs/controlling-file-size.blade.md
@@ -182,7 +182,7 @@ if (mix.inProduction()) {
         // Specify the locations of any files you want to scan for class names.
         paths: glob.sync([
           path.join(__dirname, "resources/views/**/*.blade.php"),
-          path.join(__dirname, "resources/assets/js/**/*.vue")
+          path.join(__dirname, "resources/js/**/*.vue")
         ]),
         extractors: [
           {

--- a/source/docs/controlling-file-size.blade.md
+++ b/source/docs/controlling-file-size.blade.md
@@ -182,6 +182,7 @@ if (mix.inProduction()) {
         // Specify the locations of any files you want to scan for class names.
         paths: glob.sync([
           path.join(__dirname, "resources/views/**/*.blade.php"),
+          path.join(__dirname, "resources/assets/js/**/*.vue"),
           path.join(__dirname, "resources/js/**/*.vue")
         ]),
         extractors: [


### PR DESCRIPTION
I've added the new location of the JS directory for Laravel 5.7.* so the example will work out of the box for newer projects (After learning that it didn't work for them the hard way).

I figured it made sense to also keep the old path for backwards compatibility.