### PR TITLE
Add search to the home page

### DIFF
--- a/source/_layouts/documentation.blade.php
+++ b/source/_layouts/documentation.blade.php
@@ -181,17 +181,3 @@
   </defs>
 </svg>
 @endsection
-
-@push('scripts')
-{{-- @if ($page->production) --}}
-  <!-- Algolia DocSearch  -->
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
-  <script type="text/javascript">
-    docsearch({
-      apiKey: '3df93446658cd9c4e314d4c02a052188',
-      indexName: 'tailwindcss',
-      inputSelector: '#docsearch',
-    });
-  </script>
-{{-- @endif --}}
-@endpush

--- a/source/_layouts/master.blade.php
+++ b/source/_layouts/master.blade.php
@@ -33,7 +33,17 @@
     gtag('config', 'UA-109068504-1');
   </script>
 @endif
-
+{{-- @if ($page->production) --}}
+  <!-- Algolia DocSearch  -->
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
+  <script type="text/javascript">
+    docsearch({
+      apiKey: '3df93446658cd9c4e314d4c02a052188',
+      indexName: 'tailwindcss',
+      inputSelector: '#docsearch',
+    });
+  </script>
+{{-- @endif --}}
 @stack('scripts')
 
 </body>

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -31,6 +31,16 @@
         <a class="mt-6 sm:mt-0 mx-auto sm:mx-2 max-w-xs rounded-full text-center leading-none font-semibold block px-12 py-3 border-2 border-tailwind-teal bg-tailwind-teal text-white hover:border-tailwind-teal-light hover:bg-tailwind-teal-light hover:bg-tailwind-teal-light" href="/docs/what-is-tailwind">Learn More</a>
         <a class="mt-6 sm:mt-0 mx-auto sm:mx-2 max-w-xs rounded-full text-center leading-none font-semibold block px-12 py-3 border-2 border-tailwind-teal text-tailwind-teal hover:text-white hover:border-tailwind-teal-light hover:bg-tailwind-teal-light hover:bg-tailwind-teal-light" href="https://github.com/tailwindcss/tailwindcss">GitHub</a>
       </div>
+
+      {{-- Search section --}}
+      <div class="max-w-xs mx-auto mt-6">
+        <div class="relative">
+          <input id="docsearch" class="transition focus:outline-0 border-2 border-tailwind-teal focus:bg-white focus:border-tailwind-teal-light placeholder-grey-darkest rounded-full bg-transparent py-2 pr-4 pl-10 block w-full appearance-none leading-normal" type="text" placeholder="Search the docs">
+          <div class="pointer-events-none absolute pin-y pin-l pl-3 flex items-center">
+            <svg class="fill-current pointer-events-none text-grey-dark w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42 1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12z"/></svg>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
I find myself having a hard time getting to the docs for Tailwind. And my auto complete from my browser history doesn't help a whole lot. Usually involves me clicking at least once ("learn more") and then doing a page search to find the right section to click on. After doing this a lot, I realized it would save me a lot of time if I could search the docs from the home page.

Maybe there is a better solution for this. :) But this didn't take me long and I wanted to try it out and not sure it is the best but figured it was a good conversation starter. :)

I mostly used the original code and tweaked it a bit to fit the existing buttons style a little better.

No focus:

![image](https://user-images.githubusercontent.com/191200/47424510-1f923600-d788-11e8-9cca-191eca2fad10.png)

Focus:

![image](https://user-images.githubusercontent.com/191200/47424552-33d63300-d788-11e8-946e-24cecd61c419.png)

With Content:

![image](https://user-images.githubusercontent.com/191200/47424623-536d5b80-d788-11e8-92f8-173455ff9f27.png)

