### PR TITLE
Fix wrong pseudo-class

### DIFF
--- a/source/docs/text-color.blade.md
+++ b/source/docs/text-color.blade.md
@@ -92,7 +92,7 @@ To control the text color of an element on hover, add the `hover:` prefix to any
 @endslot
 @endcomponent
 
-Hover utilities can also be combined with responsive utilities by adding the responsive `{screen}:` prefix *before* the `focus:` prefix.
+Hover utilities can also be combined with responsive utilities by adding the responsive `{screen}:` prefix *before* the `hover:` prefix.
 
 ```html
 <button class="... md:text-blue md:hover:text-blue-dark ...">Button</button>


### PR DESCRIPTION
The hover section incorrectly specifies `:focus` instead of `:hover`.