### PR TITLE
Use npx to execute tailwind

### DIFF
--- a/source/docs/installation.blade.md
+++ b/source/docs/installation.blade.md
@@ -132,10 +132,10 @@ To avoid specificity issues, we highly recommend structuring your main styleshee
 For simple projects or just giving Tailwind a spin, you can use the Tailwind CLI tool to process your CSS:
 
 <div class="bg-grey-lightest border rounded font-mono text-sm p-4">
-  <div class="text-purple-dark">./node_modules/.bin/tailwind build <span class="text-blue-dark">styles.css</span> <span class="text-grey-dark">[-c ./tailwind.js] [-o ./output.css] [--no-autoprefixer]</span></div>
+  <div class="text-purple-dark">npx tailwind <span class="text-blue-dark">build styles.css</span> <span class="text-grey-dark">[-c ./tailwind.js] [-o ./output.css] [--no-autoprefixer]</span></div>
 </div>
 
-Use the `./node_modules/.bin/tailwind help build` command to learn more about the various CLI options.
+Use the `npx tailwind help build` command to learn more about the various CLI options.
 
 #### Using Tailwind with PostCSS
 


### PR DESCRIPTION
In "Create a Tailwind config file" you used `npx tailwind` instead of `./node_modules/.bin/tailwind`, which was a good change. For consistency, the same change should be made in the "Using Tailwind CLI" section.