### PR TITLE
Rename the `flex-no-[grow/shrink]` classnames to `flex-[grow/shrink]-0` (#687)

### DIFF
--- a/source/docs/examples/forms.blade.md
+++ b/source/docs/examples/forms.blade.md
@@ -149,10 +149,10 @@ Tailwind doesn't include purpose-built form control classes out of the box, but 
 <form class="w-full max-w-sm">
   <div class="flex items-center border-b border-b-2 border-teal py-2">
     <input class="appearance-none bg-transparent border-none w-full text-grey-darker mr-3 py-1 px-2 leading-tight focus:outline-none" type="text" placeholder="Jane Doe" aria-label="Full name">
-    <button class="flex-no-shrink bg-teal hover:bg-teal-dark border-teal hover:border-teal-dark text-sm border-4 text-white py-1 px-2 rounded" type="button">
+    <button class="flex-shrink-0 bg-teal hover:bg-teal-dark border-teal hover:border-teal-dark text-sm border-4 text-white py-1 px-2 rounded" type="button">
       Sign Up
     </button>
-    <button class="flex-no-shrink border-transparent border-4 text-teal hover:text-teal-darker text-sm py-1 px-2 rounded" type="button">
+    <button class="flex-shrink-0 border-transparent border-4 text-teal hover:text-teal-darker text-sm py-1 px-2 rounded" type="button">
       Cancel
     </button>
   </div>

--- a/source/docs/examples/navigation.blade.md
+++ b/source/docs/examples/navigation.blade.md
@@ -31,7 +31,7 @@ Tailwind doesn't include pre-designed navigation components out of the box, but 
 <div class="mb-6 lg:hidden">
   <p class="text-sm text-grey-dark mb-1">Collapsed</p>
   <nav class="flex items-center justify-between flex-wrap bg-teal p-6">
-    <div class="flex items-center flex-no-shrink text-white mr-6">
+    <div class="flex items-center flex-shrink-0 text-white mr-6">
       <svg class="fill-current h-8 w-8 mr-2" width="54" height="54" viewBox="0 0 54 54" xmlns="http://www.w3.org/2000/svg"><path d="M13.5 22.1c1.8-7.2 6.3-10.8 13.5-10.8 10.8 0 12.15 8.1 17.55 9.45 3.6.9 6.75-.45 9.45-4.05-1.8 7.2-6.3 10.8-13.5 10.8-10.8 0-12.15-8.1-17.55-9.45-3.6-.9-6.75.45-9.45 4.05zM0 38.3c1.8-7.2 6.3-10.8 13.5-10.8 10.8 0 12.15 8.1 17.55 9.45 3.6.9 6.75-.45 9.45-4.05-1.8 7.2-6.3 10.8-13.5 10.8-10.8 0-12.15-8.1-17.55-9.45-3.6-.9-6.75.45-9.45 4.05z"/></svg>
       <span class="font-semibold text-xl tracking-tight">Tailwind CSS</span>
     </div>
@@ -62,7 +62,7 @@ Tailwind doesn't include pre-designed navigation components out of the box, but 
 <div>
   <p class="text-sm text-grey-dark mb-1 lg:hidden">Expanded</p>
   <nav class="flex items-center justify-between flex-wrap bg-teal p-6">
-    <div class="flex items-center flex-no-shrink text-white mr-6">
+    <div class="flex items-center flex-shrink-0 text-white mr-6">
       <svg class="fill-current h-8 w-8 mr-2" width="54" height="54" viewBox="0 0 54 54" xmlns="http://www.w3.org/2000/svg"><path d="M13.5 22.1c1.8-7.2 6.3-10.8 13.5-10.8 10.8 0 12.15 8.1 17.55 9.45 3.6.9 6.75-.45 9.45-4.05-1.8 7.2-6.3 10.8-13.5 10.8-10.8 0-12.15-8.1-17.55-9.45-3.6-.9-6.75.45-9.45 4.05zM0 38.3c1.8-7.2 6.3-10.8 13.5-10.8 10.8 0 12.15 8.1 17.55 9.45 3.6.9 6.75-.45 9.45-4.05-1.8 7.2-6.3 10.8-13.5 10.8-10.8 0-12.15-8.1-17.55-9.45-3.6-.9-6.75.45-9.45 4.05z"/></svg>
       <span class="font-semibold text-xl tracking-tight">Tailwind CSS</span>
     </div>
@@ -94,7 +94,7 @@ Tailwind doesn't include pre-designed navigation components out of the box, but 
 
 @slot('code')
 <nav class="flex items-center justify-between flex-wrap bg-teal p-6">
-  <div class="flex items-center flex-no-shrink text-white mr-6">
+  <div class="flex items-center flex-shrink-0 text-white mr-6">
     <svg class="fill-current h-8 w-8 mr-2" width="54" height="54" viewBox="0 0 54 54" xmlns="http://www.w3.org/2000/svg"><path d="M13.5 22.1c1.8-7.2 6.3-10.8 13.5-10.8 10.8 0 12.15 8.1 17.55 9.45 3.6.9 6.75-.45 9.45-4.05-1.8 7.2-6.3 10.8-13.5 10.8-10.8 0-12.15-8.1-17.55-9.45-3.6-.9-6.75.45-9.45 4.05zM0 38.3c1.8-7.2 6.3-10.8 13.5-10.8 10.8 0 12.15 8.1 17.55 9.45 3.6.9 6.75-.45 9.45-4.05-1.8 7.2-6.3 10.8-13.5 10.8-10.8 0-12.15-8.1-17.55-9.45-3.6-.9-6.75.45-9.45 4.05z"/></svg>
     <span class="font-semibold text-xl tracking-tight">Tailwind CSS</span>
   </div>

--- a/source/docs/flexbox-flex-grow-shrink.blade.md
+++ b/source/docs/flexbox-flex-grow-shrink.blade.md
@@ -42,12 +42,12 @@ features:
       "Allow a flex item to shrink if needed.",
     ],
     [
-      '.flex-no-grow',
+      '.flex-grow-0',
       'flex-grow: 0;',
       "Prevent a flex item from growing.",
     ],
     [
-      '.flex-no-shrink',
+      '.flex-shrink-0',
       'flex-shrink: 0;',
       "Prevent a flex item from shrinking.",
     ],
@@ -234,14 +234,14 @@ Use `.flex-grow` to allow a flex item to grow to fill any available space:
 
 ## Don't grow
 
-Use `.flex-no-grow` to prevent a flex item from growing:
+Use `.flex-grow-0` to prevent a flex item from growing:
 
 @component('_partials.code-sample')
 <div class="flex bg-grey-lighter">
   <div class="flex-grow text-grey-darker text-center bg-grey-light px-4 py-2 m-2">
     Will grow
   </div>
-  <div class="flex-no-grow text-grey-darkest text-center bg-grey px-4 py-2 m-2">
+  <div class="flex-grow-0 text-grey-darkest text-center bg-grey px-4 py-2 m-2">
     Will not grow
   </div>
   <div class="flex-grow text-grey-darker text-center bg-grey-light px-4 py-2 m-2">
@@ -270,14 +270,14 @@ Use `.flex-shrink` to allow a flex item to shrink if needed:
 
 ## Don't shrink
 
-Use `.flex-no-shrink` to prevent a flex item from shrinking:
+Use `.flex-shrink-0` to prevent a flex item from shrinking:
 
 @component('_partials.code-sample')
 <div class="flex bg-grey-lighter">
   <div class="flex-shrink text-grey-darker text-center bg-grey-light px-4 py-2 m-2">
     Item that can shrink if needed
   </div>
-  <div class="flex-no-shrink text-grey-darkest text-center bg-grey px-4 py-2 m-2">
+  <div class="flex-shrink-0 text-grey-darkest text-center bg-grey px-4 py-2 m-2">
     Item that cannot shrink below its initial size
   </div>
   <div class="flex-shrink text-grey-darker text-center bg-grey-light px-4 py-2 m-2">
@@ -288,7 +288,7 @@ Use `.flex-no-shrink` to prevent a flex item from shrinking:
 
 ## Responsive
 
-To control how a flex item grows or shrinks at a specific breakpoint, add a `{screen}:` prefix to any existing utility class. For example, use `md:flex-no-shrink` to apply the `flex-no-shrink` utility at only medium screen sizes and above.
+To control how a flex item grows or shrinks at a specific breakpoint, add a `{screen}:` prefix to any existing utility class. For example, use `md:flex-shrink-0` to apply the `flex-shrink-0` utility at only medium screen sizes and above.
 
 For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
 

--- a/source/docs/state-variants.blade.md
+++ b/source/docs/state-variants.blade.md
@@ -143,7 +143,7 @@ Add the `focus-within:` prefix to only apply a utility when a child element has 
 <form class="w-full max-w-sm mx-auto">
   <div class="flex items-center border-b-2 border-grey-light focus-within:border-teal py-2">
     <input class="appearance-none bg-transparent border-none w-full text-grey-darker mr-3 py-1 px-2 leading-tight focus:outline-none" type="text" placeholder="Jane Doe" aria-label="Full name">
-    <button class="focus:shadow-outline focus:outline-none flex-no-shrink bg-teal hover:bg-teal-dark border-teal hover:border-teal-dark text-sm border-4 text-white py-1 px-2 rounded" type="button">
+    <button class="focus:shadow-outline focus:outline-none flex-shrink-0 bg-teal hover:bg-teal-dark border-teal hover:border-teal-dark text-sm border-4 text-white py-1 px-2 rounded" type="button">
       Sign Up
     </button>
   </div>


### PR DESCRIPTION
This PR renames the classes `flex-no-grow` and `flex-no-shrink` to `flex-grow-0` and `flex-shrink-0`, as per https://github.com/tailwindcss/tailwindcss/pull/687