### PR TITLE
Fix border, text and background color tables

### DIFF
--- a/source/docs/background-color.blade.md
+++ b/source/docs/background-color.blade.md
@@ -10,7 +10,16 @@ features:
 ---
 
 @include('_partials.background-color-class-table', [
-  'rows' => $page->config['theme']['colors']->map(function ($value, $name) {
+  'rows' => $page->config['theme']['colors']->mapWithKeys(function ($value, $name) {
+    if (is_string($value)) {
+      return [$name => $value];
+    }
+    $result = [];
+    foreach ($value->reverse() as $variant => $color) {
+      $result["{$name}-{$variant}"] = $color;
+    }
+    return $result;
+  })->map(function ($value, $name) {
     $class = ".bg-{$name}";
     $code = "background-color: {$value};";
     $color = implode(' ', array_reverse(explode('-', $name)));

--- a/source/docs/border-color.blade.md
+++ b/source/docs/border-color.blade.md
@@ -10,7 +10,16 @@ features:
 ---
 
 @include('_partials.border-color-class-table', [
-  'rows' => $page->config['theme']['colors']->map(function ($value, $name) {
+  'rows' => $page->config['theme']['colors']->mapWithKeys(function ($value, $name) {
+    if (is_string($value)) {
+      return [$name => $value];
+    }
+    $result = [];
+    foreach ($value->reverse() as $variant => $color) {
+      $result["{$name}-{$variant}"] = $color;
+    }
+    return $result;
+  })->map(function ($value, $name) {
     $class = ".border-{$name}";
     $code = "border-color: {$value};";
     $color = implode(' ', array_reverse(explode('-', $name)));

--- a/source/docs/text-color.blade.md
+++ b/source/docs/text-color.blade.md
@@ -10,7 +10,16 @@ features:
 ---
 
 @include('_partials.text-color-class-table', [
-  'rows' => $page->config['theme']['colors']->map(function ($value, $name) {
+  'rows' => $page->config['theme']['colors']->mapWithKeys(function ($value, $name) {
+    if (is_string($value)) {
+      return [$name => $value];
+    }
+    $result = [];
+    foreach ($value->reverse() as $variant => $color) {
+      $result["{$name}-{$variant}"] = $color;
+    }
+    return $result;
+  })->map(function ($value, $name) {
     $class = ".text-{$name}";
     $code = "color: {$value};";
     $color = implode(' ', array_reverse(explode('-', $name)));


### PR DESCRIPTION
The color tables currently display a JSON string for all colors except transparent, white and black. This PR fixes that by introducing an extra `mapWithKeys` call to split out the color collections before formatting them.