### PR TITLE
Added custom font class back to the body tag

### DIFF
--- a/source/_layouts/master.blade.php
+++ b/source/_layouts/master.blade.php
@@ -18,7 +18,7 @@
   <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
   @stack('headScripts')
 </head>
-<body data-sidebar-visible="true" class="text-gray-900 leading-normal">
+<body data-sidebar-visible="true" class="font-source-sans text-gray-900 leading-normal">
 
 @yield('body')
 


### PR DESCRIPTION
I'm assuming we still want Source Sans Pro as the font for the docs? The `source-sans` class has been migrated to the new Tailwind config at least...