### PR TITLE
Add missing semicolons on color pages

### DIFF
--- a/source/docs/background-color.blade.md
+++ b/source/docs/background-color.blade.md
@@ -13,7 +13,7 @@ features:
   'rows' => $page->config['theme']['colors']->flatMap(function ($colors, $name) {
     if (is_string($colors)) {
       return [
-        [".bg-{$name}", "color: {$colors}"]
+        [".bg-{$name}", "color: {$colors};"]
       ];
     }
 

--- a/source/docs/border-color.blade.md
+++ b/source/docs/border-color.blade.md
@@ -13,7 +13,7 @@ features:
   'rows' => $page->config['theme']['colors']->flatMap(function ($colors, $name) {
     if (is_string($colors)) {
       return [
-        [".border-{$name}", "color: {$colors}"]
+        [".border-{$name}", "color: {$colors};"]
       ];
     }
 

--- a/source/docs/text-color.blade.md
+++ b/source/docs/text-color.blade.md
@@ -13,7 +13,7 @@ features:
   'rows' => $page->config['theme']['colors']->flatMap(function ($colors, $name) {
     if (is_string($colors)) {
       return [
-        [".text-{$name}", "color: {$colors}"]
+        [".text-{$name}", "color: {$colors};"]
       ];
     }
 


### PR DESCRIPTION
The `transparent`, `black`, and `white` colors were missing a trailing semicolon on the background/border/text color pages.