### PR TITLE
Add dedicated search page and OpenSearch meta

### DIFF
--- a/source/_layouts/documentation.blade.php
+++ b/source/_layouts/documentation.blade.php
@@ -190,7 +190,7 @@
   <!-- Algolia DocSearch  -->
   <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
   <script type="text/javascript">
-    docsearch({
+    const search = docsearch({
       apiKey: '3df93446658cd9c4e314d4c02a052188',
       indexName: 'tailwindcss',
       inputSelector: '#docsearch',

--- a/source/_layouts/master.blade.php
+++ b/source/_layouts/master.blade.php
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="{{ mix('/css/main.css') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css">
   <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
+  <link rel="search" type="application/opensearchdescription+xml" title="TailwindCSS Docs Search" href="/opensearch.xml">
   @stack('headScripts')
 </head>
 <body data-sidebar-visible="true" class="font-source-sans font-normal text-black leading-normal">

--- a/source/docs/search.blade.php
+++ b/source/docs/search.blade.php
@@ -4,18 +4,16 @@
 
 @push('scripts')
 <script type="text/javascript">
-    (function(){
+    $.when($.ready).then(function() {
         document.addEventListener('DOMContentLoaded', function() {
             const urlParams = new URLSearchParams(window.location.search);
             const query = urlParams.get('q');
+            
             const docsearchAutocomplete = search.autocomplete; // The underlying autocomplete.js instance
             const autocomplete = docsearchAutocomplete.autocomplete; 
 
             autocomplete.setVal(query);
             autocomplete.open();
-            docsearchAutocomplete.on('autocomplete:closed', (event) => {
-                autocomplete.open();
-            });
         });
     }());
 </script>

--- a/source/docs/search.blade.php
+++ b/source/docs/search.blade.php
@@ -1,0 +1,22 @@
+@extends('_layouts.documentation')
+
+{{-- No content --}}
+
+@push('scripts')
+<script type="text/javascript">
+    (function(){
+        document.addEventListener('DOMContentLoaded', function() {
+            const urlParams = new URLSearchParams(window.location.search);
+            const query = urlParams.get('q');
+            const docsearchAutocomplete = search.autocomplete; // The underlying autocomplete.js instance
+            const autocomplete = docsearchAutocomplete.autocomplete; 
+
+            autocomplete.setVal(query);
+            autocomplete.open();
+            docsearchAutocomplete.on('autocomplete:closed', (event) => {
+                autocomplete.open();
+            });
+        });
+    }());
+</script>
+@endpush

--- a/source/opensearch.blade.xml
+++ b/source/opensearch.blade.xml
@@ -4,10 +4,10 @@
 
 <Description>Search TailwindCSS Docs</Description>
 <InputEncoding>UTF-8</InputEncoding>
-<Url type="text/html" method="get" template="https://tailwindcss.com/docs/search">
+<Url type="text/html" method="get" template="{{ $page->baseUrl }}/docs/search">
   <Param name="q" value="{searchTerms}"/>
 </Url>
 <Url type="application/opensearchdescription+xml"
      rel="self"
-     template="https://tailwindcss.com/opensearch.xml"/>
+     template="{{ $page->baseUrl }}/opensearch.xml"/>
 </OpenSearchDescription>

--- a/source/opensearch.xml
+++ b/source/opensearch.xml
@@ -1,0 +1,13 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http:/www.mozilla.org/2006/browser/search/">
+<ShortName>TailwindCSS Docs</ShortName>
+
+<Description>Search TailwindCSS Docs</Description>
+<InputEncoding>UTF-8</InputEncoding>
+<Url type="text/html" method="get" template="https://tailwindcss.com/docs/search">
+  <Param name="q" value="{searchTerms}"/>
+</Url>
+<Url type="application/opensearchdescription+xml"
+     rel="self"
+     template="https://tailwindcss.com/opensearch.xml"/>
+</OpenSearchDescription>


### PR DESCRIPTION
This PR adds a dedicated search page located at `/docs/search` and implements [OpenSearch](https://developer.mozilla.org/en-US/docs/Web/OpenSearch) so that users can add custom search engines (tested in Chrome and Firefox).

This search page provides some of the benefits of a server-side rendered search (dedicated URL and search param) without straying from Algolia's Docsearch implementation.

**How to use**:
1. From your browser, visit `/docs/search?q=color`
1. See the search page and results for the query "color"

~~Note: the search results box will not close on the search page.~~

**TODO:**
- [x] The autocomplete suggestions will not go away if you navigate to a different page.
  - Fixed by making the autocomplete suggestions not locked open

**Further reading**: 
- [Adding a Custom search engine in Chrome](https://www.techrepublic.com/article/pro-tip-add-custom-search-engines-in-chrome-for-more-efficient-searching/)