### PR TITLE
Document new list utilities

### DIFF
--- a/source/docs/lists.blade.md
+++ b/source/docs/lists.blade.md
@@ -12,16 +12,31 @@ features:
 @include('_partials.class-table', [
   'rows' => [
     [
-      '.list-reset',
-      "list-style: none; padding: 0;",
-      "Disable default browser styling for lists and list items.",
+      '.list-none',
+      "list-style-type: none;",
+    ],
+    [
+      '.list-disc',
+      "list-style-type: disc;",
+    ],
+    [
+      '.list-decimal',
+      "list-style-type: decimal;",
+    ],
+    [
+      '.list-inside',
+      "list-style-position: inside;",
+    ],
+    [
+      '.list-outside',
+      "list-style-position: outside;",
     ],
   ]
 ])
 
-## Removing default list styling
+## Styling lists
 
-Remove default list styles using the `.list-reset` utility.
+By default lists are unstyled. That means if you want to create lists that have the default browser styling (bullets/numbers and a bit of left padding), you need to explicitly style those.
 
 @component('_partials.code-sample')
 <div class="mb-6">
@@ -33,26 +48,43 @@ Remove default list styles using the `.list-reset` utility.
   </ul>
 </p>
 </div>
-<div>
-  <p class="text-sm text-gray-600">With .list-reset</p>
-  <ul class="list-reset">
+<div class="mb-6">
+  <p class="text-sm text-gray-600">Styled unordered list</p>
+  <ul class="list-disc list-inside">
     <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
     <li>Assumenda, quia temporibus eveniet a libero incidunt suscipit</li>
     <li>Quidem, ipsam illum quis sed voluptatum quae eum fugit earum</li>
   </ul>
 </div>
+<div>
+  <p class="text-sm text-gray-600">Styled ordered list</p>
+  <ol class="list-decimal list-inside">
+    <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
+    <li>Assumenda, quia temporibus eveniet a libero incidunt suscipit</li>
+    <li>Quidem, ipsam illum quis sed voluptatum quae eum fugit earum</li>
+  </ol>
+</div>
 @slot('code')
-<ul class="list-reset">
+<ul>
   <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
-  <li>Assumenda, quia temporibus eveniet a libero incidunt suscipit</li>
-  <li>Quidem, ipsam illum quis sed voluptatum quae eum fugit earum</li>
+  ...
 </ul>
+
+<ul class="list-disc list-inside">
+  <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
+  ...
+</ul>
+
+<ol class="list-decimal list-inside">
+  <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
+  ...
+</ol>
 @endslot
 @endcomponent
 
 ## Responsive
 
-To preserve default list styles until a specific breakpoint, add a `{screen}:` prefix to the `.list-reset` utilitiy. For example, use `.md:list-reset` to apply the `.list-reset` utility at only medium screen sizes and above.
+To control the list styles of an element at a specific breakpoint, add a `{screen}:` prefix to any existing list utility. For example, use `.md:list-disc` to apply the `.list-disc` utility at only medium screen sizes and above.
 
 For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
 
@@ -65,35 +97,35 @@ For more information about Tailwind's responsive design features, check out the 
 </ul>
 @endslot
 @slot('sm')
-<ul class="list-reset">
+<ul class="list-disc">
   <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
   <li>Assumenda, quia temporibus eveniet a libero incidunt suscipit</li>
   <li>Quidem, ipsam illum quis sed voluptatum quae eum fugit earum</li>
 </ul>
 @endslot
 @slot('md')
-<ul class="list-reset">
+<ul class="list-decimal">
   <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
   <li>Assumenda, quia temporibus eveniet a libero incidunt suscipit</li>
   <li>Quidem, ipsam illum quis sed voluptatum quae eum fugit earum</li>
 </ul>
 @endslot
 @slot('lg')
-<ul class="list-reset">
+<ul class="list-disc list-inside">
   <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
   <li>Assumenda, quia temporibus eveniet a libero incidunt suscipit</li>
   <li>Quidem, ipsam illum quis sed voluptatum quae eum fugit earum</li>
 </ul>
 @endslot
 @slot('xl')
-<ul class="list-reset">
+<ul class="list-decimal list-inside">
   <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
   <li>Assumenda, quia temporibus eveniet a libero incidunt suscipit</li>
   <li>Quidem, ipsam illum quis sed voluptatum quae eum fugit earum</li>
 </ul>
 @endslot
 @slot('code')
-<ul class="sm:list-reset md:list-reset lg:list-reset xl:list-reset">
+<ul class="sm:list-disc md:list-decimal lg:list-disc lg:list-inside xl:list-decimal xl:list-inside">
   <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit</li>
   <li>Assumenda, quia temporibus eveniet a libero incidunt suscipit</li>
   <li>Quidem, ipsam illum quis sed voluptatum quae eum fugit earum</li>


### PR DESCRIPTION
This PR documents the new list utilities and updates the examples to show how to add back the default browser styling to lists.

One thing I found when documenting this is that the 'variants and disabling' partial currently does not allow specifying multiple plugins. This will be required because of the new split from `lists` to `listStylePosition` and `listStyleType` (and others).