### PR TITLE
Fix incorrect CSS code for background and border base colors

### DIFF
--- a/source/docs/background-color.blade.md
+++ b/source/docs/background-color.blade.md
@@ -13,7 +13,7 @@ features:
   'rows' => $page->config['theme']['colors']->flatMap(function ($colors, $name) {
     if (is_string($colors)) {
       return [
-        [".bg-{$name}", "color: {$colors};"]
+        [".bg-{$name}", "background-color: {$colors};"]
       ];
     }
 

--- a/source/docs/border-color.blade.md
+++ b/source/docs/border-color.blade.md
@@ -13,7 +13,7 @@ features:
   'rows' => $page->config['theme']['colors']->flatMap(function ($colors, $name) {
     if (is_string($colors)) {
       return [
-        [".border-{$name}", "color: {$colors};"]
+        [".border-{$name}", "border-color: {$colors};"]
       ];
     }
 


### PR DESCRIPTION
On the background and border color pages the code for the transparent/black/white colors incorrectly display as `color` instead of `background-color` and `border-color`.