### PR TITLE
Rename `modules` to `variants`

### DIFF
--- a/source/docs/configuration.blade.md
+++ b/source/docs/configuration.blade.md
@@ -275,7 +275,7 @@ To completely disable a module, set it to `false`:
 module.exports = {
   // ...
 
-  modules: {
+  variants: {
 
     // Don't include this module at all.
     appearance: false,


### PR DESCRIPTION
rename `modules` key to `variants` in the disable module section of configuration page.`