### PR TITLE
Split Flex, Grow, & Shrink into separate pages

### DIFF
--- a/navigation.php
+++ b/navigation.php
@@ -61,7 +61,9 @@ return [
         'Align Content' => 'flexbox-align-content',
         'Align Self' => 'flexbox-align-self',
         'Justify Content' => 'flexbox-justify-content',
-        'Flex, Grow, &amp; Shrink' => 'flexbox-flex-grow-shrink',
+        'Flex' => 'flexbox-flex',
+        'Flex Grow' => 'flexbox-flex-grow',
+        'Flex Shrink' => 'flexbox-flex-shrink',
     ],
     'Spacing' => [
         'Padding' => 'padding',

--- a/source/docs/flexbox-flex-grow.blade.md
+++ b/source/docs/flexbox-flex-grow.blade.md
@@ -1,0 +1,167 @@
+---
+extends: _layouts.documentation
+title: "Flex Grow"
+description: "Utilities for controlling how flex items grow."
+features:
+  responsive: true
+  customizable: true
+  hover: false
+  focus: false
+---
+
+@include('_partials.class-table', [
+  'rows' => [
+    [
+      '.flex-grow',
+      'flex-grow: 1;',
+      "Allow a flex item to grow to fill any available space.",
+    ],
+    [
+      '.flex-grow-0',
+      'flex-grow: 0;',
+      "Prevent a flex item from growing.",
+    ],
+  ]
+])
+
+## Grow
+
+Use `.flex-grow` to allow a flex item to grow to fill any available space:
+
+@component('_partials.code-sample')
+<div class="flex bg-gray-200">
+  <div class="flex-none text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Content that cannot flex
+  </div>
+  <div class="flex-grow text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Item that will grow
+  </div>
+  <div class="flex-none text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Content that cannot flex
+  </div>
+</div>
+@endcomponent
+
+## Don't grow
+
+Use `.flex-grow-0` to prevent a flex item from growing:
+
+@component('_partials.code-sample')
+<div class="flex bg-gray-200">
+  <div class="flex-grow text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Will grow
+  </div>
+  <div class="flex-grow-0 text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Will not grow
+  </div>
+  <div class="flex-grow text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Will grow
+  </div>
+</div>
+@endcomponent
+
+## Responsive
+
+To control how a flex item grows at a specific breakpoint, add a `{screen}:` prefix to any existing utility class. For example, use `md:flex-grow-0` to apply the `flex-grow-0` utility at only medium screen sizes and above.
+
+For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
+
+@component('_partials.responsive-code-sample')
+@slot('none')
+<div class="flex bg-gray-200">
+  <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+  <div class="flex-grow-0 text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Responsive flex item
+  </div>
+  <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+</div>
+@endslot
+@slot('sm')
+<div class="flex bg-gray-200">
+  <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+  <div class="flex-grow text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Responsive flex item
+  </div>
+  <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+</div>
+@endslot
+@slot('md')
+<div class="flex bg-gray-200">
+  <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+  <div class="flex-grow-0 text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Responsive flex item
+  </div>
+  <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+</div>
+@endslot
+@slot('lg')
+<div class="flex bg-gray-200">
+  <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+  <div class="flex-grow text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Responsive flex item
+  </div>
+  <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+</div>
+@endslot
+@slot('xl')
+<div class="flex bg-gray-200">
+  <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+  <div class="flex-grow-0 text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Responsive flex item
+  </div>
+  <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+</div>
+@endslot
+@slot('code')
+<div class="flex ...">
+  <!-- ... -->
+  <div class="none:flex-grow-0 sm:flex-grow md:flex-grow-0 lg:flex-grow xl:flex-grow-0 ...">
+    Responsive flex item
+  </div>
+  <!-- ... -->
+</div>
+@endslot
+@endcomponent
+
+## Customizing
+
+### Grow Values
+
+By default Tailwind provides two `flex-grow` utilities. You change, add, or remove these by editing the `flexGrow` section of your Tailwind config.
+
+@component('_partials.customized-config', ['key' => 'flexGrow'])
+  '0': 0,
+- default: 1,
++ default: 2,
++ '1': 1,
+@endcomponent
+
+@include('_partials.variants-and-disabling', [
+    'utility' => [
+        'name' => 'flex grow',
+        'property' => 'flexGrow',
+    ],
+    'variants' => [
+        'responsive',
+    ],
+])

--- a/source/docs/flexbox-flex-shrink.blade.md
+++ b/source/docs/flexbox-flex-shrink.blade.md
@@ -1,0 +1,167 @@
+---
+extends: _layouts.documentation
+title: "Flex Shrink"
+description: "Utilities for controlling how flex items shrink."
+features:
+  responsive: true
+  customizable: true
+  hover: false
+  focus: false
+---
+
+@include('_partials.class-table', [
+  'rows' => [
+    [
+      '.flex-shrink',
+      'flex-shrink: 1;',
+      "Allow a flex item to shrink if needed.",
+    ],
+    [
+      '.flex-shrink-0',
+      'flex-shrink: 0;',
+      "Prevent a flex item from shrinking.",
+    ],
+  ]
+])
+
+## Shrink
+
+Use `.flex-shrink` to allow a flex item to shrink if needed:
+
+@component('_partials.code-sample')
+<div class="flex bg-gray-200">
+  <div class="flex-none text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Longer content that cannot flex
+  </div>
+  <div class="flex-shrink text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Item that will shrink even if it causes the content to wrap
+  </div>
+  <div class="flex-none text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Longer content that cannot flex
+  </div>
+</div>
+@endcomponent
+
+## Don't shrink
+
+Use `.flex-shrink-0` to prevent a flex item from shrinking:
+
+@component('_partials.code-sample')
+<div class="flex bg-gray-200">
+  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can shrink if needed
+  </div>
+  <div class="flex-shrink-0 text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Item that cannot shrink below its initial size
+  </div>
+  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can shrink if needed
+  </div>
+</div>
+@endcomponent
+
+## Responsive
+
+To control how a flex item shrinks at a specific breakpoint, add a `{screen}:` prefix to any existing utility class. For example, use `md:flex-shrink-0` to apply the `flex-shrink-0` utility at only medium screen sizes and above.
+
+For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
+
+@component('_partials.responsive-code-sample')
+@slot('none')
+<div class="flex bg-gray-200">
+  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+  <div class="flex-shrink text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Responsive flex item
+  </div>
+  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+</div>
+@endslot
+@slot('sm')
+<div class="flex bg-gray-200">
+  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+  <div class="flex-shrink-0 text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Responsive flex item
+  </div>
+  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+</div>
+@endslot
+@slot('md')
+<div class="flex bg-gray-200">
+  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+  <div class="flex-shrink text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Responsive flex item
+  </div>
+  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+</div>
+@endslot
+@slot('lg')
+<div class="flex bg-gray-200">
+  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+  <div class="flex-shrink-0 text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Responsive flex item
+  </div>
+  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+</div>
+@endslot
+@slot('xl')
+<div class="flex bg-gray-200">
+  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+  <div class="flex-shrink text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+    Responsive flex item
+  </div>
+  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
+    Item that can grow or shrink if needed
+  </div>
+</div>
+@endslot
+@slot('code')
+<div class="flex ...">
+  <!-- ... -->
+  <div class="none:flex-shrink sm:flex-shrink-0 md:flex-shrink lg:flex-shrink-0 xl:flex-shrink ...">
+    Responsive flex item
+  </div>
+  <!-- ... -->
+</div>
+@endslot
+@endcomponent
+
+## Customizing
+
+### Shrink Values
+
+By default Tailwind provides two `flex-shrink` utilities. You change, add, or remove these by editing the `flexShrink` section of your Tailwind config.
+
+@component('_partials.customized-config', ['key' => 'flexShrink'])
+  '0': 0,
+- default: 1,
++ default: 2,
++ '1': 1,
+@endcomponent
+
+@include('_partials.variants-and-disabling', [
+    'utility' => [
+        'name' => 'flex shrink',
+        'property' => 'flexShrink',
+    ],
+    'variants' => [
+        'responsive',
+    ],
+])

--- a/source/docs/flexbox-flex.blade.md
+++ b/source/docs/flexbox-flex.blade.md
@@ -1,10 +1,10 @@
 ---
 extends: _layouts.documentation
-title: "Flex, Grow, &amp; Shrink"
-description: "Utilities for controlling how flex items grow and shrink."
+title: "Flex"
+description: "Utilities for controlling how flex items both grow and shrink."
 features:
   responsive: true
-  customizable: false
+  customizable: true
   hover: false
   focus: false
 ---
@@ -13,43 +13,23 @@ features:
   'rows' => [
     [
       '.flex-initial',
-      'flex: initial;',
+      'flex: 0 1 auto;',
       "Allow a flex item to shrink but not grow, taking into account its initial size.",
     ],
     [
       '.flex-1',
-      'flex: 1;',
+      'flex: 1 1 0%;',
       "Allow a flex item to grow and shrink as needed, ignoring its initial size.",
     ],
     [
       '.flex-auto',
-      'flex: auto;',
+      'flex: 1 1 auto;',
       "Allow a flex item to grow and shrink, taking into account its initial size.",
     ],
     [
       '.flex-none',
       'flex: none;',
       "Prevent a flex item from growing or shrinking.",
-    ],
-    [
-      '.flex-grow',
-      'flex-grow: 1;',
-      "Allow a flex item to grow to fill any available space.",
-    ],
-    [
-      '.flex-shrink',
-      'flex-shrink: 1;',
-      "Allow a flex item to shrink if needed.",
-    ],
-    [
-      '.flex-grow-0',
-      'flex-grow: 0;',
-      "Prevent a flex item from growing.",
-    ],
-    [
-      '.flex-shrink-0',
-      'flex-shrink: 0;',
-      "Prevent a flex item from shrinking.",
     ],
   ]
 ])
@@ -214,81 +194,9 @@ Use `.flex-none` to prevent a flex item from growing or shrinking:
 </div>
 @endcomponent
 
-## Grow
-
-Use `.flex-grow` to allow a flex item to grow to fill any available space:
-
-@component('_partials.code-sample')
-<div class="flex bg-gray-200">
-  <div class="flex-none text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
-    Content that cannot flex
-  </div>
-  <div class="flex-grow text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
-    Item that will grow
-  </div>
-  <div class="flex-none text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
-    Content that cannot flex
-  </div>
-</div>
-@endcomponent
-
-## Don't grow
-
-Use `.flex-grow-0` to prevent a flex item from growing:
-
-@component('_partials.code-sample')
-<div class="flex bg-gray-200">
-  <div class="flex-grow text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
-    Will grow
-  </div>
-  <div class="flex-grow-0 text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
-    Will not grow
-  </div>
-  <div class="flex-grow text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
-    Will grow
-  </div>
-</div>
-@endcomponent
-
-## Shrink
-
-Use `.flex-shrink` to allow a flex item to shrink if needed:
-
-@component('_partials.code-sample')
-<div class="flex bg-gray-200">
-  <div class="flex-none text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
-    Longer content that cannot flex
-  </div>
-  <div class="flex-shrink text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
-    Item that will shrink even if it causes the content to wrap
-  </div>
-  <div class="flex-none text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
-    Longer content that cannot flex
-  </div>
-</div>
-@endcomponent
-
-## Don't shrink
-
-Use `.flex-shrink-0` to prevent a flex item from shrinking:
-
-@component('_partials.code-sample')
-<div class="flex bg-gray-200">
-  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
-    Item that can shrink if needed
-  </div>
-  <div class="flex-shrink-0 text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
-    Item that cannot shrink below its initial size
-  </div>
-  <div class="flex-shrink text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
-    Item that can shrink if needed
-  </div>
-</div>
-@endcomponent
-
 ## Responsive
 
-To control how a flex item grows or shrinks at a specific breakpoint, add a `{screen}:` prefix to any existing utility class. For example, use `md:flex-shrink-0` to apply the `flex-shrink-0` utility at only medium screen sizes and above.
+To control how a flex item both grows and shrinks at a specific breakpoint, add a `{screen}:` prefix to any existing utility class. For example, use `md:flex-1` to apply the `flex-1` utility at only medium screen sizes and above.
 
 For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
 
@@ -311,7 +219,7 @@ For more information about Tailwind's responsive design features, check out the 
   <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
     Item that can grow or shrink if needed
   </div>
-  <div class="flex-grow text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+  <div class="flex-1 text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
     Responsive flex item
   </div>
   <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
@@ -324,7 +232,7 @@ For more information about Tailwind's responsive design features, check out the 
   <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
     Item that can grow or shrink if needed
   </div>
-  <div class="flex-shrink text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+  <div class="flex-auto text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
     Responsive flex item
   </div>
   <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
@@ -337,7 +245,7 @@ For more information about Tailwind's responsive design features, check out the 
   <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
     Item that can grow or shrink if needed
   </div>
-  <div class="flex-1 text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+  <div class="flex-initial text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
     Responsive flex item
   </div>
   <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
@@ -350,7 +258,7 @@ For more information about Tailwind's responsive design features, check out the 
   <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
     Item that can grow or shrink if needed
   </div>
-  <div class="flex-initial text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
+  <div class="flex-1 text-gray-800 text-center bg-gray-500 px-4 py-2 m-2">
     Responsive flex item
   </div>
   <div class="flex-1 text-gray-700 text-center bg-gray-400 px-4 py-2 m-2">
@@ -361,7 +269,7 @@ For more information about Tailwind's responsive design features, check out the 
 @slot('code')
 <div class="flex ...">
   <!-- ... -->
-  <div class="none:flex-none sm:flex-grow md:flex-shrink lg:flex-1 xl:flex-auto ...">
+  <div class="none:flex-none sm:flex-1 md:flex-auto lg:flex-initial xl:flex-1 ...">
     Responsive flex item
   </div>
   <!-- ... -->
@@ -371,13 +279,25 @@ For more information about Tailwind's responsive design features, check out the 
 
 ## Customizing
 
+### Flex Values
+
+By default Tailwind provides four `flex` utilities. You change, add, or remove these by editing the `flex` section of your Tailwind config.
+
+@component('_partials.customized-config', ['key' => 'flex'])
+  '1': '1 1 0%',
+  auto: '1 1 auto',
+- initial: '0 1 auto',
++ inherit: 'inherit',
+  none: 'none',
++ '2': '2 2 0%',
+@endcomponent
+
 @include('_partials.variants-and-disabling', [
     'utility' => [
-        'name' => 'flex, grow, and shrink',
-        'property' => 'flexbox',
+        'name' => 'flex',
+        'property' => 'flex',
     ],
     'variants' => [
         'responsive',
     ],
-    'extraMessage' => 'Note that modifying the <code>flexbox</code> property will affect which variants are generated for <em>all</em> Flexbox utilities, not just the flex, grow, and shrink utilities.'
 ])


### PR DESCRIPTION
This PR splits up the 'Flex, Grow, & Shrink' page into a 'Flex', 'Flex Grow', and 'Flex Shrink' page to document the new customization possibilities.