### PR TITLE
Fix incorrect active page highlighting

### DIFF
--- a/config.php
+++ b/config.php
@@ -11,7 +11,7 @@ return [
         $pages = collect(array_wrap($page));
 
         return $pages->contains(function ($page) use ($path) {
-            return str_contains($page->getPath(), $path);
+            return $page->getPath() === $path;
         });
     },
     'anyChildrenActive' => function ($page, $children) {


### PR DESCRIPTION
The new flex page structure (#121) causes the 'Flex' page to also be highlighted when visiting the 'Flex Grow' and 'Flex Shrink' pages. This PR fixes that.
It could possibly be simplified further by just doing `return $page->getPath() === $path;` without the collection wrapping and contains loop, but I wasn't sure if there is any current behavior that relies on this.