### PR TITLE
Add object-fit usage example

### DIFF
--- a/source/docs/object-fit.blade.md
+++ b/source/docs/object-fit.blade.md
@@ -36,6 +36,77 @@ description: "Utilities for controlling the element's respond to the height and 
     ]
 ])
 
+## Usage
+
+@component('_partials.code-sample')
+<div class="flex flex-wrap bg-gray-200">
+  <div class="p-4 mb-2">
+    <p class="mb-2 text-gray-700">.object-contain</p>
+    <div class="h-32 w-64 bg-gray-400">
+      <img class="h-full w-full object-contain" src="https://user-images.githubusercontent.com/4323180/37476373-5f8b7524-284b-11e8-8bc3-8dcb98dd2685.png" alt="">
+    </div>
+  </div>
+  <div class="p-4 mb-2">
+    <p class="mb-2 text-gray-700">.object-cover</p>
+    <div class="h-32 w-64 bg-gray-400">
+      <img class="h-full w-full object-cover" src="https://user-images.githubusercontent.com/4323180/37476373-5f8b7524-284b-11e8-8bc3-8dcb98dd2685.png" alt="">
+    </div>
+  </div>
+  <div class="p-4 mb-2">
+    <p class="mb-2 text-gray-700">.object-fill</p>
+    <div class="h-32 w-64 bg-gray-400">
+      <img class="h-full w-full object-fill" src="https://user-images.githubusercontent.com/4323180/37476373-5f8b7524-284b-11e8-8bc3-8dcb98dd2685.png" alt="">
+    </div>
+  </div>
+  <div class="p-4 mb-2">
+    <p class="mb-2 text-gray-700">.object-none</p>
+    <div class="h-32 w-64 bg-gray-400">
+      <img class="h-full w-full object-none" src="https://user-images.githubusercontent.com/4323180/37476373-5f8b7524-284b-11e8-8bc3-8dcb98dd2685.png" alt="">
+    </div>
+  </div>
+  <div class="p-4 mb-2">
+    <p class="mb-2 text-gray-700">.object-scale-down</p>
+    <div class="h-32 w-64 bg-gray-400">
+      <img class="h-full w-full object-scale-down" src="https://user-images.githubusercontent.com/4323180/37476373-5f8b7524-284b-11e8-8bc3-8dcb98dd2685.png" alt="">
+    </div>
+  </div>
+</div>
+@slot('code')
+<div class="flex flex-wrap bg-gray-200">
+  <div class="p-4 mb-2">
+    <p class="mb-2 text-gray-700">.object-contain</p>
+    <div class="h-32 w-64 bg-gray-400">
+      <img class="h-full w-full object-contain ...">
+    </div>
+  </div>
+  <div class="p-4 mb-2">
+    <p class="mb-2 text-gray-700">.object-cover</p>
+    <div class="h-32 w-64 bg-gray-400">
+      <img class="h-full w-full object-cover ...">
+    </div>
+  </div>
+  <div class="p-4 mb-2">
+    <p class="mb-2 text-gray-700">.object-fill</p>
+    <div class="h-32 w-64 bg-gray-400">
+      <img class="h-full w-full object-fill ...">
+    </div>
+  </div>
+  <div class="p-4 mb-2">
+    <p class="mb-2 text-gray-700">.object-none</p>
+    <div class="h-32 w-64 bg-gray-400">
+      <img class="h-full w-full object-none ...">
+    </div>
+  </div>
+  <div class="p-4 mb-2">
+    <p class="mb-2 text-gray-700">.object-scale-down</p>
+    <div class="h-32 w-64 bg-gray-400">
+      <img class="h-full w-full object-scale-down ...">
+    </div>
+  </div>
+</div>
+@endslot
+@endcomponent
+
 ## Customizing
 
 @include('_partials.variants-and-disabling', [


### PR DESCRIPTION
This adds a usage example to the Object Fit page.  It is based on the old example from https://github.com/tailwindcss/plugin-examples.  Lemme know if you want me to change the url of the sample image to something else.  Also let me know if you want me to remove the "work in progress".

![image](https://user-images.githubusercontent.com/3342530/55279751-64e80000-52f2-11e9-9e62-081dae1a8950.png)
