### PR TITLE
Update position documentation

### DIFF
--- a/source/docs/position.blade.md
+++ b/source/docs/position.blade.md
@@ -36,76 +36,6 @@ features:
       "position: sticky;",
       "Position an element relatively until its containing block crosses a specified threshold, then position it relative to the viewport.",
     ],
-    [
-      '.top-0',
-      "top: 0;",
-      "Anchor absolutely positioned element to the top edge of the nearest positioned parent.",
-    ],
-    [
-      '.right-0',
-      "right: 0;",
-      "Anchor absolutely positioned element to the right edge of the nearest positioned parent.",
-    ],
-    [
-      '.bottom-0',
-      "bottom: 0;",
-      "Anchor absolutely positioned element to the bottom edge of the nearest positioned parent.",
-    ],
-    [
-      '.left-0',
-      "left: 0;",
-      "Anchor absolutely positioned element to the left edge of the nearest positioned parent.",
-    ],
-    [
-      '.inset-y-0',
-      "top: 0;\nbottom: 0;",
-      "Anchor absolutely positioned element to the top and bottom edges of the nearest positioned parent.",
-    ],
-    [
-      '.inset-x-0',
-      "right: 0;\nleft: 0;",
-      "Anchor absolutely positioned element to the left and right edges of the nearest positioned parent.",
-    ],
-    [
-      '.inset-0',
-      "top: 0;\nright: 0;\nbottom: 0;\nleft: 0;",
-      "Anchor absolutely positioned element to all the edges of the nearest positioned parent.",
-    ],
-    [
-      '.inset-auto',
-      "top: auto;\nright: auto;\nbottom: auto;\nleft: auto;",
-      "Reset absolutely positioned element to all the edges from a given breakpoint onwards.",
-    ],
-    [
-      '.top-auto',
-      "top: auto;",
-      "Reset absolutely positioned element to the top edge",
-    ],
-    [
-      '.bottom-auto',
-      "bottom: auto;",
-      "Reset absolutely positioned element to the bottom edge",
-    ],
-    [
-      '.left-auto',
-      "left: auto;",
-      "Reset absolutely positioned element to the left edge",
-    ],
-    [
-      '.right-auto',
-      "right: auto;",
-      "Reset absolutely positioned element to the right edge",
-    ],
-    [
-      '.inset-y-auto',
-      "top: auto;\nbottom: auto;",
-      "Reset absolutely positioned element to the top and bottom edge",
-    ],
-    [
-      '.inset-x-auto',
-      "left: auto;\nright: auto;",
-      "Reset absolutely positioned element to the left and right edge",
-    ],
   ]
 ])
 
@@ -307,210 +237,58 @@ Offsets are calculated relative to the element's normal position and the element
 @endslot
 @endcomponent
 
-## Pinning edges
-
-Use the `.{top|right|bottom|left|inset}-{value}` utilities to anchor absolutely positioned elements against any of the edges of the nearest positioned parent.
-
-Combined with Tailwind's [spacing utilities](/docs/spacing), you'll probably find that these are all you need to precisely control absolutely positioned elements.
-
-<div class="flex items-start mt-8 text-sm leading-none mb-8">
-  <div class="pr-12">
-    <div class="mb-3 text-gray-700 uppercase">Class</div>
-    <div><code class="inline-block my-1 mr-1 px-2 py-1 font-mono border rounded">top|right|bottom|left|inset</code></div>
-  </div>
-  <div class="pl-12 pr-12 border-l">
-    <div class="mb-3 text-gray-700">
-    <span class="uppercase">space</span>
-  </div>
-  <div><code class="inline-block my-1 mr-1 px-2 py-1 font-mono border rounded">0</code> 0</div>
-  <div><code class="inline-block my-1 mr-1 px-2 py-1 font-mono border rounded">auto</code> auto</div>
-  </div>
-</div>
-
-@component('_partials.code-sample')
-<div class="flex justify-around mb-8">
-  <div>
-    <p class="text-center text-sm text-gray-600 mb-1">.inset-x-0.top-0</p>
-    <div class="relative h-24 w-24 bg-gray-400">
-      <div class="absolute inset-x-0 top-0 h-8 bg-gray-700"></div>
-    </div>
-  </div>
-  <div>
-    <p class="text-center text-sm text-gray-600 mb-1">.inset-y-0.right-0</p>
-    <div class="relative h-24 w-24 bg-gray-400">
-      <div class="absolute inset-y-0 right-0 w-8 bg-gray-700"></div>
-    </div>
-  </div>
-  <div>
-    <p class="text-center text-sm text-gray-600 mb-1">.inset-x-0.bottom-0</p>
-    <div class="relative h-24 w-24 bg-gray-400">
-      <div class="absolute inset-x-0 bottom-0 h-8 bg-gray-700"></div>
-    </div>
-  </div>
-  <div>
-    <p class="text-center text-sm text-gray-600 mb-1">.inset-y-0.left-0</p>
-    <div class="relative h-24 w-24 bg-gray-400">
-      <div class="absolute inset-y-0 left-0 w-8 bg-gray-700"></div>
-    </div>
-  </div>
-  <div>
-    <p class="text-center text-sm text-gray-600 mb-1">.inset-0</p>
-    <div class="relative h-24 w-24 bg-gray-400">
-      <div class="absolute inset-0 bg-gray-700"></div>
-    </div>
-  </div>
-</div>
-<div class="flex justify-around">
-  <div>
-    <p class="text-center text-sm text-gray-600 mb-1">.left-0.top-0</p>
-    <div class="relative h-24 w-24 bg-gray-400">
-      <div class="absolute left-0 top-0 h-8 w-8 bg-gray-700"></div>
-    </div>
-  </div>
-  <div>
-    <p class="text-center text-sm text-gray-600 mb-1">.top-0.right-0</p>
-    <div class="relative h-24 w-24 bg-gray-400">
-      <div class="absolute top-0 right-0 h-8 w-8 bg-gray-700"></div>
-    </div>
-  </div>
-  <div>
-    <p class="text-center text-sm text-gray-600 mb-1">.right-0.bottom-0</p>
-    <div class="relative h-24 w-24 bg-gray-400">
-      <div class="absolute right-0 bottom-0 h-8 w-8 bg-gray-700"></div>
-    </div>
-  </div>
-  <div>
-    <p class="text-center text-sm text-gray-600 mb-1">.bottom-0.left-0</p>
-    <div class="relative h-24 w-24 bg-gray-400">
-      <div class="absolute bottom-0 left-0 h-8 w-8 bg-gray-700"></div>
-    </div>
-  </div>
-  <div class="relative h-24 w-24 opacity-0"></div>
-</div>
-
-@slot('code')
-<!-- Span top edge -->
-<div class="relative h-24 w-24 bg-gray-400">
-  <div class="absolute inset-x-0 top-0 h-8 bg-gray-700"></div>
-</div>
-
-<!-- Span right edge -->
-<div class="relative h-24 w-24 bg-gray-400">
-  <div class="absolute inset-y-0 right-0 w-8 bg-gray-700"></div>
-</div>
-
-<!-- Span bottom edge -->
-<div class="relative h-24 w-24 bg-gray-400">
-  <div class="absolute inset-x-0 bottom-0 h-8 bg-gray-700"></div>
-</div>
-
-<!-- Span left edge -->
-<div class="relative h-24 w-24 bg-gray-400">
-  <div class="absolute inset-y-0 left-0 bg-gray-700"></div>
-</div>
-
-<!-- Fill entire parent -->
-<div class="relative h-24 w-24 bg-gray-400">
-  <div class="absolute inset-0 bg-gray-700"></div>
-</div>
-
-<!-- Pin to top left corner -->
-<div class="relative h-24 w-24 bg-gray-400">
-  <div class="absolute left-0 top-0 h-8 w-8 bg-gray-700"></div>
-</div>
-
-<!-- Pin to top right corner -->
-<div class="relative h-24 w-24 bg-gray-400">
-  <div class="absolute top-0 right-0 h-8 w-8 bg-gray-700"></div>
-</div>
-
-<!-- Pin to bottom right corner -->
-<div class="relative h-24 w-24 bg-gray-400">
-  <div class="absolute bottom-0 right-0 h-8 w-8 bg-gray-700"></div>
-</div>
-
-<!-- Pin to bottom left corner -->
-<div class="relative h-24 w-24 bg-gray-400">
-  <div class="absolute bottom-0 left-0 h-8 w-8 bg-gray-700"></div>
-</div>
-@endslot
-@endcomponent
-
 ## Responsive
 
-To position an element only at a specific breakpoint, add a `{screen}:` prefix to any existing positioning utility. For example, adding the class `md:absolute` to an element would apply the `absolute` utility at medium screen sizes and above, and adding `lg:inset-y-0` would apply `inset-y-0` at large screens and above.
+To change how an element is positioned only at a specific breakpoint, add a `{screen}:` prefix to any existing position utility. For example, adding the class `md:absolute` to an element would apply the `absolute` utility at medium screen sizes and above.
 
 For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
 
 @component('_partials.responsive-code-sample')
 @slot('none')
 <div class="relative h-32 bg-gray-400 p-4">
-  <div class="relative bg-gray-800 p-4 text-gray-500">Responsive element</div>
+  <div class="relative inset-x-0 bottom-0 bg-gray-800 p-4 text-gray-500">Responsive element</div>
 </div>
 @endslot
 
 @slot('sm')
 <div class="relative h-32 bg-gray-400 p-4">
-  <div class="absolute bottom-0 left-0 bg-gray-800 p-4 text-gray-500">Responsive element</div>
+  <div class="absolute inset-x-0 bottom-0 bg-gray-800 p-4 text-gray-500">Responsive element</div>
 </div>
 @endslot
 
 @slot('md')
 <div class="relative h-32 bg-gray-400 p-4">
-  <div class="absolute top-0 inset-x-0 bg-gray-800 p-4 text-gray-500">Responsive element</div>
+  <div class="fixed inset-x-0 bottom-0 z-100 bg-gray-800 p-4 text-gray-500">Responsive element</div>
 </div>
 @endslot
 
 @slot('lg')
 <div class="relative h-32 bg-gray-400 p-4">
-  <div class="absolute right-0 inset-y-0 bg-gray-800 p-4 text-gray-500">Responsive element</div>
+  <div class="absolute inset-x-0 bottom-0 bg-gray-800 p-4 text-gray-500">Responsive element</div>
 </div>
 @endslot
 
 @slot('xl')
 <div class="relative h-32 bg-gray-400 p-4">
-  <div class="absolute bottom-0 inset-x-0 bg-gray-800 p-4 text-gray-500">Responsive element</div>
+  <div class="relative inset-x-0 bottom-0 bg-gray-800 p-4 text-gray-500">Responsive element</div>
 </div>
 @endslot
 
 @slot('code')
 <div class="relative h-32 bg-gray-400 p-4">
-  <div class="none:relative sm:absolute sm:bottom-0 sm:left-0 md:top-0 md:inset-x-0 lg:right-0 lg:inset-y-0 xl:bottom-0 xl:inset-x-0"></div>
+  <div class="inset-x-0 bottom-0 none:relative sm:absolute md:fixed lg:absolute xl:relative"></div>
 </div>
 @endslot
 @endcomponent
 
 ## Customizing
 
-```javascript
-module.exports = {
-  theme: {
-    position: {
-      '0': 0,
-      auto: 'auto',
-    },
-  }
-}
-```
-
-```javascript
-module.exports = {
-  theme: {
-    inset: {
-      '0': 0,
-      auto: 'auto',
-    },
-  }
-}
-```
-
-The classes of the inset live in a new inset plugin instead of the position plugin, so their variants are also controlled separately:
-
-```javascript
-module.exports = {
-  variants: {
-    position: ['responsive'],
-    inset: ['responsive'],
-  }
-}
-```
+@include('_partials.variants-and-disabling', [
+    'utility' => [
+        'name' => 'position',
+        'property' => 'position',
+    ],
+    'variants' => [
+        'responsive',
+    ],
+])

--- a/source/docs/top-right-bottom-left.blade.md
+++ b/source/docs/top-right-bottom-left.blade.md
@@ -196,14 +196,14 @@ Combined with Tailwind's [spacing utilities](/docs/spacing), you'll probably fin
 
 ## Responsive
 
-To position an element only at a specific breakpoint, add a `{screen}:` prefix to any existing positioning utility. For example, adding the class `md:absolute` to an element would apply the `absolute` utility at medium screen sizes and above, and adding `lg:inset-y-0` would apply `inset-y-0` at large screens and above.
+To position an element only at a specific breakpoint, add a `{screen}:` prefix to any existing positioning utility. For example, adding the class `md:inset-y-0` to an element would apply the `inset-y-0` utility at medium screen sizes and above.
 
 For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
 
 @component('_partials.responsive-code-sample')
 @slot('none')
 <div class="relative h-32 bg-gray-400 p-4">
-  <div class="relative bg-gray-800 p-4 text-gray-500">Responsive element</div>
+  <div class="absolute inset-0 bg-gray-800 p-4 text-gray-500">Responsive element</div>
 </div>
 @endslot
 
@@ -233,12 +233,22 @@ For more information about Tailwind's responsive design features, check out the 
 
 @slot('code')
 <div class="relative h-32 bg-gray-400 p-4">
-  <div class="none:relative sm:absolute sm:bottom-0 sm:left-0 md:top-0 md:inset-x-0 lg:right-0 lg:inset-y-0 xl:bottom-0 xl:inset-x-0"></div>
+  <div class="none:absolute none:inset-0 sm:bottom-0 sm:left-0 md:top-0 md:inset-x-0 lg:right-0 lg:inset-y-0 xl:bottom-0 xl:inset-x-0"></div>
 </div>
 @endslot
 @endcomponent
 
 ## Customizing
+
+### Positions
+
+By default Tailwind provides utilities for `0` and `auto` positions for each side. You change, add, or remove these by editing the `theme.inset` section of your Tailwind config.
+
+@component('_partials.customized-config', ['key' => 'theme.inset'])
+  '0': 0,
+- auto: 'auto',
++ '1/2': '50%',
+@endcomponent
 
 @include('_partials.variants-and-disabling', [
     'utility' => [


### PR DESCRIPTION
This PR removes the top/right/bottom/left utilities and examples from the Position docs, and changes the responsive examples to focus more on the `position` property.
It also updates the responsive examples and adds customization documentation to the top/right/bottom/left page