### PR TITLE
Fix plugins diff in section 2.7

### DIFF
--- a/source/docs/upgrading-to-v1.blade.md
+++ b/source/docs/upgrading-to-v1.blade.md
@@ -407,7 +407,7 @@ If you are taking advantage the `center` or `padding` options exposed by the `co
 -       center: true,
 -       padding: '1rem',
 -     }),
--   ],
+    ],
   }
 ```
 


### PR DESCRIPTION
The last diff in section 2.7 was removing the matching square bracket for the plugins section