### PR TITLE
Correct logical mistake concerning priority

### DIFF
--- a/source/docs/functions-and-directives.blade.md
+++ b/source/docs/functions-and-directives.blade.md
@@ -197,7 +197,7 @@ This will generate the following CSS:
 
 It's important to note that **variants are generated in the order you specify them**.
 
-So if you want focus utilities to take priority over hover utilities for example, make sure focus comes *before* hover in the list:
+So if you want focus utilities to take priority over hover utilities for example, make sure focus comes *after* hover in the list:
 
 ```less
 // Input


### PR DESCRIPTION
Focus utilities have to come AFTER hover utilities in the list if they should take priority over hover utilities.