### PR TITLE
Finish whitespace and word break docs

### DIFF
--- a/source/docs/whitespace.blade.md
+++ b/source/docs/whitespace.blade.md
@@ -4,8 +4,6 @@ title: "Whitespace"
 description: "Utilities for controlling an element's white-space property."
 ---
 
-@include('_partials.work-in-progress')
-
 @include('_partials.class-table', [
   'rows' => [
     [
@@ -35,6 +33,113 @@ description: "Utilities for controlling an element's white-space property."
     ],
   ]
 ])
+
+## Normal
+
+Use `.whitespace-normal` to cause text to wrap normally within an element. Newlines and spaces will be collapsed.
+
+@component('_partials.code-sample')
+<div class="whitespace-normal">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Omnis quidem itaque beatae, rem tenetur quia iure,
+    eum natus enim maxime
+    laudantium quibusdam illo nihil,
+
+reprehenderit saepe quam aliquid odio accusamus.</div>
+@endcomponent
+
+## No Wrap
+
+Use `.whitespace-no-wrap` to prevent text from wrapping within an element. Newlines and spaces will be collapsed.
+
+@component('_partials.code-sample')
+<div class="whitespace-no-wrap overflow-x-auto">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Omnis quidem itaque beatae, rem tenetur quia iure,
+    eum natus enim maxime
+    laudantium quibusdam illo nihil,
+
+reprehenderit saepe quam aliquid odio accusamus.</div>
+@endcomponent
+
+## Pre
+
+Use `.whitespace-pre` to preserve newlines and spaces within an element. Text will not be wrapped.
+
+@component('_partials.code-sample')
+<div class="whitespace-pre overflow-x-auto">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Omnis quidem itaque beatae, rem tenetur quia iure,
+    eum natus enim maxime
+    laudantium quibusdam illo nihil,
+
+reprehenderit saepe quam aliquid odio accusamus.</div>
+@endcomponent
+
+## Pre Line
+
+Use `.whitespace-pre-line` to preserve newlines but not spaces within an element. Text will be wrapped normally.
+
+@component('_partials.code-sample')
+<div class="whitespace-pre-line">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Omnis quidem itaque beatae, rem tenetur quia iure,
+    eum natus enim maxime
+    laudantium quibusdam illo nihil,
+
+reprehenderit saepe quam aliquid odio accusamus.</div>
+@endcomponent
+
+## Pre Wrap
+
+Use `.whitespace-pre-wrap` to preserve newlines and spaces within an element. Text will be wrapped normally.
+
+@component('_partials.code-sample')
+<div class="whitespace-pre-wrap">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Omnis quidem itaque beatae, rem tenetur quia iure,
+    eum natus enim maxime
+    laudantium quibusdam illo nihil,
+
+reprehenderit saepe quam aliquid odio accusamus.</div>
+@endcomponent
+
+## Responsive
+
+To control the whitespace property of an element only at a specific breakpoint, add a `{screen}:` prefix to any existing whitespace utility. For example, adding the class `md:whitespace-pre` to an element would apply the `whitespace-pre` utility at medium screen sizes and above.
+
+For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
+
+@component('_partials.responsive-code-sample')
+@slot('none')
+<div class="whitespace-normal overflow-x-auto">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Omnis quidem itaque beatae, rem tenetur quia iure,
+    eum natus enim maxime
+    laudantium quibusdam illo nihil,
+
+reprehenderit saepe quam aliquid odio accusamus.</div>
+@endslot
+@slot('sm')
+<div class="whitespace-no-wrap overflow-x-auto">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Omnis quidem itaque beatae, rem tenetur quia iure,
+    eum natus enim maxime
+    laudantium quibusdam illo nihil,
+
+reprehenderit saepe quam aliquid odio accusamus.</div>
+@endslot
+@slot('md')
+<div class="whitespace-pre overflow-x-auto">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Omnis quidem itaque beatae, rem tenetur quia iure,
+    eum natus enim maxime
+    laudantium quibusdam illo nihil,
+
+reprehenderit saepe quam aliquid odio accusamus.</div>
+@endslot
+@slot('lg')
+<div class="whitespace-pre-line overflow-x-auto">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Omnis quidem itaque beatae, rem tenetur quia iure,
+    eum natus enim maxime
+    laudantium quibusdam illo nihil,
+
+reprehenderit saepe quam aliquid odio accusamus.</div>
+@endslot
+@slot('xl')
+<div class="whitespace-pre-wrap overflow-x-auto">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Omnis quidem itaque beatae, rem tenetur quia iure,
+    eum natus enim maxime
+    laudantium quibusdam illo nihil,
+
+reprehenderit saepe quam aliquid odio accusamus.</div>
+@endslot
+@slot('code')
+<div class="none:whitespace-normal sm:whitespace-no-wrap md:whitespace-pre lg:whitespace-pre-line xl:whitespace-pre-wrap ...">...</div>
+@endslot
+@endcomponent
 
 ## Customizing
 

--- a/source/docs/word-break.blade.md
+++ b/source/docs/word-break.blade.md
@@ -4,8 +4,6 @@ title: "Word Break"
 description: "Utilities for controlling word breaks in an element."
 ---
 
-@include('_partials.work-in-progress')
-
 @include('_partials.class-table', [
   'rows' => [
     [
@@ -30,6 +28,97 @@ description: "Utilities for controlling word breaks in an element."
     ],
   ]
 ])
+
+## Normal <span class="ml-2 font-semibold text-gray-600 text-sm uppercase tracking-wide">Default</span>
+
+Use `.break-normal` to only add line breaks at normal word break points.
+
+@component('_partials.code-sample')
+<p class="break-normal max-w-xs p-2 bg-gray-200 mx-auto">
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit cum.
+</p>
+@slot('code')
+<p class="break-normal ...">...</p>
+@endslot
+@endcomponent
+
+## Break Words
+
+Use `.break-words` to add line breaks mid-word if needed.
+
+@component('_partials.code-sample')
+<p class="break-words max-w-xs p-2 bg-gray-200 mx-auto">
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit cum.
+</p>
+@slot('code')
+<p class="break-words ...">...</p>
+@endslot
+@endcomponent
+
+## Break All
+
+Use `.break-all` to add line breaks whenever necessary, without trying to preserve whole words.
+
+@component('_partials.code-sample')
+<p class="break-all max-w-xs p-2 bg-gray-200 mx-auto">
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit cum.
+</p>
+@slot('code')
+<p class="break-words ...">...</p>
+@endslot
+@endcomponent
+
+## Truncate
+
+Use `.truncate` to truncate overflowing text with an ellipsis (<code>…</code>) if needed.
+
+@component('_partials.code-sample')
+<p class="truncate max-w-xs p-2 bg-gray-200 mx-auto">
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit cum.
+</p>
+@slot('code')
+<p class="truncate ...">...</p>
+@endslot
+@endcomponent
+
+## Responsive
+
+To control the word breaks in an element only at a specific breakpoint, add a `{screen}:` prefix to any existing word break utility. For example, adding the class `md:break-all` to an element would apply the `break-all` utility at medium screen sizes and above.
+
+For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
+
+@component('_partials.responsive-code-sample')
+@slot('none')
+<p class="break-normal max-w-xs p-2 bg-gray-200 mx-auto">
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit cum.
+</p>
+@endslot
+@slot('sm')
+<p class="break-words max-w-xs p-2 bg-gray-200 mx-auto">
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit cum.
+</p>
+@endslot
+@slot('md')
+<p class="break-all max-w-xs p-2 bg-gray-200 mx-auto">
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit cum.
+</p>
+@endslot
+@slot('lg')
+<p class="truncate max-w-xs p-2 bg-gray-200 mx-auto">
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit cum.
+</p>
+@endslot
+@slot('xl')
+<p class="break-normal max-w-xs p-2 bg-gray-200 mx-auto">
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiisitaquequodpraesentiumexplicaboincidunt? Dolores beatae nam at sed dolorum ratione dolorem nisi velit cum.
+</p>
+@endslot
+@slot('code')
+<p class="none:break-normal sm:break-words md:break-all lg:truncate xl:break-normal ...">
+    ...
+</p>
+@endslot
+@endcomponent
 
 ## Customizing
 


### PR DESCRIPTION
Document all whitespace and word break utilities and add responsive examples. This finishes the 'Typography' section of the documentation