### PR TITLE
Update padding, margin, and negative margin docs

### DIFF
--- a/source/docs/margin.blade.md
+++ b/source/docs/margin.blade.md
@@ -9,8 +9,6 @@ features:
   focus: false
 ---
 
-@include('_partials.work-in-progress')
-
 @include('_partials.class-table', [
   'scroll' => true,
   'rows' => collect([
@@ -28,7 +26,7 @@ features:
         return "{$property}: {$value};";
       })->implode("\n");
       return [$class, $code];
-    });
+    })->values();
   })
 ])
 
@@ -93,12 +91,12 @@ For more information about Tailwind's responsive design features, check out the 
 
 ### Margins
 
-By default Tailwind provides 19 fixed `margin` utilities and an `auto` utility. These utilities will also be generated for every side and axis. You change, add, or remove these by editing the `theme.margin` section of your Tailwind config. The values in this section will also control which utilities will be generated per side/axis.
+By default Tailwind provides 19 fixed `margin` utilities and an `auto` utility. These utilities will also be generated for every side and axis. You change, add, or remove these by editing the `theme.margin` section of your `tailwind.config.js` file.
 
 @component('_partials.customized-config', ['key' => 'theme.margin', 'usesTheme' => true])
 - 'auto': 'auto',
   ...theme('spacing'),
-+ '28': '7rem',
++ '72': '18rem',
 + '2px': '2px',
 @endcomponent
 

--- a/source/docs/negative-margin.blade.md
+++ b/source/docs/negative-margin.blade.md
@@ -9,8 +9,6 @@ features:
   focus: false
 ---
 
-@include('_partials.work-in-progress')
-
 @include('_partials.class-table', [
   'scroll' => true,
   'rows' => collect([
@@ -29,7 +27,7 @@ features:
         return "{$property}: {$value};";
       })->implode("\n");
       return [$class, $code];
-    });
+    })->values();
   })
 ])
 
@@ -39,7 +37,61 @@ Control an element's negative margin using the `.-m{side?}-{size}` utilities.
 
 For example, `.-m-6` would add `-1.5rem` of margin on all sides of an element, `.-mx-4` would make the horizontal margin `-1rem`, and `.-mt-2` would add `-.5rem` of margin to the top of the element.
 
+## Responsive
+
+To control the negative margin of an element at a specific breakpoint, add a `{screen}:` prefix to any existing negative margin utility. For example, adding the class `md:-mt-4` to an element would apply the `-mt-4` utility at medium screen sizes and above.
+
+For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
+
+@component('_partials.responsive-code-sample', ['class' => 'text-center pt-8'])
+@slot('none')
+<div class="inline-block bg-purple-400 p-8">
+    <div class="w-48 h-48 bg-gray-300 -ml-6"></div>
+</div>
+@endslot
+
+@slot('sm')
+<div class="inline-block bg-purple-400 p-8">
+    <div class="w-48 h-48 bg-gray-300 -ml-6 -mr-6"></div>
+</div>
+@endslot
+
+@slot('md')
+<div class="inline-block bg-purple-400 p-8">
+    <div class="w-48 h-48 bg-gray-300 -ml-6 -mr-6 -mt-12"></div>
+</div>
+@endslot
+
+@slot('lg')
+<div class="inline-block bg-purple-400 p-8">
+    <div class="w-48 h-48 bg-gray-300 -ml-6 -mr-6 -mt-12 -mb-2"></div>
+</div>
+@endslot
+
+@slot('xl')
+<div class="inline-block bg-purple-400 p-8">
+    <div class="w-48 h-48 bg-gray-300 -m-2"></div>
+</div>
+@endslot
+
+@slot('code')
+<div class="p-8 ...">
+    <div class="none:-ml-6 sm:-mr-6 md:-mt-12 lg:-mb-2 xl:-m-2 ..."></div>
+</div>
+@endslot
+@endcomponent
+
 ## Customizing
+
+### Negative Margins
+
+By default Tailwind provides 19 fixed negative `margin` utilities. These utilities will also be generated for every side and axis. You change, add, or remove these by editing the `theme.negativeMargin` section of your `tailwind.config.js` file.
+
+@component('_partials.customized-config', ['key' => 'theme.negativeMargin', 'usesTheme' => true])
+  ...theme('spacing'),
++ '72': '18rem',
++ '2px': '2px',
+@endcomponent
 
 @include('_partials.variants-and-disabling', [
     'utility' => [

--- a/source/docs/padding.blade.md
+++ b/source/docs/padding.blade.md
@@ -9,8 +9,6 @@ features:
   focus: false
 ---
 
-@include('_partials.work-in-progress')
-
 @include('_partials.class-table', [
   'scroll' => true,
   'rows' => collect([
@@ -28,7 +26,7 @@ features:
         return "{$property}: {$value};";
       })->implode("\n");
       return [$class, $code];
-    });
+    })->values();
   })
 ])
 
@@ -38,7 +36,61 @@ Control an element's padding using the `.p{side?}-{size}` utilities.
 
 For example, `.p-6` would add `1.5rem` of padding on all sides of an element, `.px-0` would make the horizontal padding zero, and `.pt-2` would add `.5rem` of padding to the top of the element.
 
+## Responsive
+
+To control the padding of an element at a specific breakpoint, add a `{screen}:` prefix to any existing padding utility. For example, adding the class `md:py-8` to an element would apply the `py-8` utility at medium screen sizes and above.
+
+For more information about Tailwind's responsive design features, check out the [Responsive Design](/docs/responsive-design) documentation.
+
+@component('_partials.responsive-code-sample', ['class' => 'text-center'])
+@slot('none')
+<div class="inline-block bg-purple-400 pt-8">
+    <div class="w-48 h-48 bg-gray-300"></div>
+</div>
+@endslot
+
+@slot('sm')
+<div class="inline-block bg-purple-400 pt-8 pr-6">
+    <div class="w-48 h-48 bg-gray-300"></div>
+</div>
+@endslot
+
+@slot('md')
+<div class="inline-block bg-purple-400 pt-8 pr-6 pb-4">
+    <div class="w-48 h-48 bg-gray-300"></div>
+</div>
+@endslot
+
+@slot('lg')
+<div class="inline-block bg-purple-400 pt-8 pr-8 pb-4 pl-2">
+    <div class="w-48 h-48 bg-gray-300"></div>
+</div>
+@endslot
+
+@slot('xl')
+<div class="inline-block bg-purple-400 p-0">
+    <div class="w-48 h-48 bg-gray-300"></div>
+</div>
+@endslot
+
+@slot('code')
+<div class="none:pt-8 sm:pr-6 md:pb-4 lg:pl-2 xl:p-0 ...">
+    <!-- ... -->
+</div>
+@endslot
+@endcomponent
+
 ## Customizing
+
+### Paddings
+
+By default Tailwind provides 19 fixed `padding` utilities. These utilities will also be generated for every side and axis. You change, add, or remove these by editing the `theme.padding` section of your `tailwind.config.js` file.
+
+@component('_partials.customized-config', ['key' => 'theme.padding', 'usesTheme' => true])
+  ...theme('spacing'),
++ '72': '18rem',
++ '2px': '2px',
+@endcomponent
 
 @include('_partials.variants-and-disabling', [
     'utility' => [


### PR DESCRIPTION
Added customization and responsive examples. Also fixed a bug where the `auto` and `px` utilities were only shown for the `ml`, `pl`, and `-ml` variants.