### PR TITLE
Use rgba over color keywords, for macOS Safari

### DIFF
--- a/source/_layouts/homepage.blade.php
+++ b/source/_layouts/homepage.blade.php
@@ -116,7 +116,7 @@
     {{-- Side nav --}}
     <div id="sidebar" class="hidden absolute z-90 top-16 bg-white w-full border-b -mb-16 lg:-mb-0 lg:static lg:bg-transparent lg:border-b-0 lg:pt-0 lg:w-1/4 lg:block lg:border-0 xl:w-1/5">
       <div id="navWrapper" class="lg:block lg:relative lg:sticky lg:top-0 overflow-hidden">
-        <div id="nav" class="h-16 pointer-events-none absolute inset-x-0 z-10" style="background-image: linear-gradient(white, transparent);"></div>
+        <div id="nav" class="h-16 pointer-events-none absolute inset-x-0 z-10" style="background-image: linear-gradient(rgba(255,255,255,1), rgba(255,255,255,0));"></div>
         <nav class="px-6 pt-6 overflow-y-auto text-base lg:text-sm lg:py-12 lg:pl-6 lg:pr-8 sticky?lg:h-screen">
           @foreach ($page->navigation as $sectionName => $sectionItems)
           <div class="mb-8">


### PR DESCRIPTION
macOS Safari seems to prefer Reba over the keywords in linear gradient