### PR TITLE
Add usage examples for cursors

### DIFF
--- a/source/docs/cursor.blade.md
+++ b/source/docs/cursor.blade.md
@@ -9,8 +9,6 @@ features:
   focus: false
 ---
 
-@include('_partials.work-in-progress')
-
 @include('_partials.class-table', [
   'rows' => [
     [
@@ -50,6 +48,111 @@ features:
     ],
   ]
 ])
+
+## Auto <span class="ml-2 font-semibold text-gray-600 text-sm uppercase tracking-wide">Default</span>
+
+Use `.cursor-auto` to allow the browser to change the cursor based on the current content (e.g. automatically change to `text` cursor when hovering over text).
+
+@component('_partials.code-sample', ['class' => 'text-center'])
+<div class="cursor-auto max-w-xs p-2 bg-gray-200 mx-auto">
+  Hover over this text
+</div>
+@slot('code')
+<div class="cursor-auto ...">
+  Hover over this text
+</div>
+@endslot
+@endcomponent
+
+## Default
+
+Use `.cursor-default` to change the mouse cursor to always use the platform-dependent default cursor (usually an arrow).
+
+@component('_partials.code-sample', ['class' => 'text-center'])
+<div class="cursor-default max-w-xs p-2 bg-gray-200 mx-auto">
+  Hover over this text
+</div>
+@slot('code')
+<div class="cursor-default ...">
+  Hover over this text
+</div>
+@endslot
+@endcomponent
+
+## Pointer
+
+Use `.cursor-pointer` to change the mouse cursor to indicate an interactive element (usually a pointing hand).
+
+@component('_partials.code-sample', ['class' => 'text-center'])
+<div class="cursor-pointer max-w-xs p-2 bg-gray-200 mx-auto">
+  Hover me
+</div>
+@slot('code')
+<div class="cursor-pointer ...">
+  Hover me
+</div>
+@endslot
+@endcomponent
+
+## Pointer
+
+Use `.cursor-wait` to change the mouse cursor to indicate something is happening in the background (usually an hourglass or watch).
+
+@component('_partials.code-sample', ['class' => 'text-center'])
+<div class="cursor-wait max-w-xs p-2 bg-gray-200 mx-auto">
+  Hover me
+</div>
+@slot('code')
+<div class="cursor-wait ...">
+  Hover me
+</div>
+@endslot
+@endcomponent
+
+## Text
+
+Use `.cursor-text` to change the mouse cursor to indicate the text can be selected (usually an I-beam shape).
+
+@component('_partials.code-sample', ['class' => 'text-center'])
+<div class="cursor-text max-w-xs p-2 bg-gray-200 mx-auto">
+  Hover me
+</div>
+@slot('code')
+<div class="cursor-text ...">
+  Hover me
+</div>
+@endslot
+@endcomponent
+
+## Move
+
+Use `.cursor-move` to change the mouse cursor to indicate the something that can be moved.
+
+@component('_partials.code-sample', ['class' => 'text-center'])
+<div class="cursor-move max-w-xs p-2 bg-gray-200 mx-auto">
+  Hover me
+</div>
+@slot('code')
+<div class="cursor-move ...">
+  Hover me
+</div>
+@endslot
+@endcomponent
+
+## Not Allowed
+
+Use `.cursor-not-allowed` to change the mouse cursor to indicate the something that can not be interacted with or clicked.
+
+@component('_partials.code-sample', ['class' => 'text-center'])
+<div class="cursor-not-allowed max-w-xs p-2 bg-gray-200 mx-auto">
+  Hover me
+</div>
+@slot('code')
+<div class="cursor-not-allowed ...">
+  Hover me
+</div>
+@endslot
+@endcomponent
 
 ## Customizing
 

--- a/source/docs/cursor.blade.md
+++ b/source/docs/cursor.blade.md
@@ -126,7 +126,7 @@ Use `.cursor-text` to change the mouse cursor to indicate the text can be select
 
 ## Move
 
-Use `.cursor-move` to change the mouse cursor to indicate the something that can be moved.
+Use `.cursor-move` to change the mouse cursor to indicate something that can be moved.
 
 @component('_partials.code-sample', ['class' => 'text-center'])
 <div class="cursor-move max-w-xs p-2 bg-gray-200 mx-auto">
@@ -141,7 +141,7 @@ Use `.cursor-move` to change the mouse cursor to indicate the something that can
 
 ## Not Allowed
 
-Use `.cursor-not-allowed` to change the mouse cursor to indicate the something that can not be interacted with or clicked.
+Use `.cursor-not-allowed` to change the mouse cursor to indicate something can not be interacted with or clicked.
 
 @component('_partials.code-sample', ['class' => 'text-center'])
 <div class="cursor-not-allowed max-w-xs p-2 bg-gray-200 mx-auto">


### PR DESCRIPTION
:wave:

Here are some examples for using the `cursor-{style}` utilities.

Used as reference for some of the more esoteric terms (TIL: `cursor-text` is an 'I-beam'):
- https://developer.mozilla.org/en-US/docs/Web/CSS/cursor
- https://developer.apple.com/design/human-interface-guidelines/macos/user-interaction/mouse-and-trackpad/#pointers
- https://docs.microsoft.com/en-us/windows/desktop/uxguide/inter-mouse#common-pointer-shapes

Preview: https://deploy-preview-184--elated-stonebraker-70896a.netlify.com/docs/cursor