### PR TITLE
Add custom cursors example

### DIFF
--- a/source/docs/cursor.blade.md
+++ b/source/docs/cursor.blade.md
@@ -172,6 +172,31 @@ By default Tailwind provides six `cursor` utilities. You change, add, or remove 
 + 'zoom-in': 'zoom-in',
 @endcomponent
 
+You can also use `cursor` to generate custom utilities using images instead of the system defaults. Learn more about how custom cursor images work over at [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor).
+
+@component('_partials.customized-config', ['key' => 'theme.cursor'])
+  pointer: 'pointer',
+  'custom-bitmap': "url('http://127.0.0.1:8080/apple-touch-icon.png')",
+@endcomponent
+
+Using SVGs from your project is also a possibility. You can do so by adding [`postcss-inline-svg`](https://github.com/TrySound/postcss-inline-svg) to your PostCSS config file.
+
+@component('_partials.customized-config', ['key' => 'theme.cursor'])
+  pointer: 'pointer',
+  'custom-vector': "svg-load('cross.svg', fill=#fff, width=50, height=50) 25 25, not-allowed",
+@endcomponent
+
+```js
+// postcss.config.js
+module.exports = {
+  plugins: [
+    require('tailwindcss'),
+    require('postcss-inline-svg'),
+    require('autoprefixer'),
+  ],
+}
+```
+
 @include('_partials.variants-and-disabling', [
     'utility' => [
         'name' => 'cursor',


### PR DESCRIPTION
This PR adds a couple examples on how to deal with custom cursor images (either bitmap or svg vectors).

EDIT: There might be all kinds of errors. Had to put it together real fast before leaving the studio. Let me know if there's anything that should change before merging.