### PR TITLE
Updates Laravel Mix documentation link.

### DIFF
--- a/source/docs/installation.blade.md
+++ b/source/docs/installation.blade.md
@@ -185,7 +185,7 @@ mix.sass('resources/sass/app.scss', 'public/css')
   })
 ```
 
-For more information on what this feature does and the implications of disabling it, [see the Laravel Mix documentation](https://github.com/JeffreyWay/laravel-mix/blob/master/docs/css-preprocessors.md#css-url-rewriting).
+For more information on what this feature does and the implications of disabling it, [see the Laravel Mix documentation](https://laravel-mix.com/docs/4.0/css-preprocessors#css-url-rewriting).
 
 ### Webpack Encore
 


### PR DESCRIPTION
Updates the Laravel Mix docs link from:

```
https://github.com/JeffreyWay/laravel-mix/blob/master/docs/css-preprocessors.md#css-url-rewriting
```

to

```
https://laravel-mix.com/docs/4.0/css-preprocessors#css-url-rewriting
```