### PR TITLE
Change URL references from next to master

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/source/docs/configuration.blade.md
+++ b/source/docs/configuration.blade.md
@@ -35,7 +35,7 @@ module.exports = {
 }
 ```
 
-Every section of the config file is optional, so you only have to specify what you'd like to change. Any missing sections will fall back to Tailwind's [default configuration](https://github.com/tailwindcss/tailwindcss/blob/next/stubs/defaultConfig.stub.js).
+Every section of the config file is optional, so you only have to specify what you'd like to change. Any missing sections will fall back to Tailwind's [default configuration](https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js).
 
 ## Creating your configuration file
 

--- a/source/docs/theme.blade.md
+++ b/source/docs/theme.blade.md
@@ -40,13 +40,13 @@ module.exports = {
 }
 ```
 
-We provide a sensible [default theme](https://github.com/tailwindcss/tailwindcss/blob/next/stubs/defaultConfig.stub.js#L5) with a very generous set of values to get you started, but don't be afraid to change it or extend; you're encouraged to customize it as much as you need to to fit the goals of your design.
+We provide a sensible [default theme](https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js#L5) with a very generous set of values to get you started, but don't be afraid to change it or extend; you're encouraged to customize it as much as you need to to fit the goals of your design.
 
 ## Theme structure
 
 The `theme` object contains keys for `screens`, `colors`, and `spacing`, as well as a key for each customizable [core plugin](/docs/core-plugins).
 
-See the [theme configuration reference](#configuration-reference) or the [default theme](https://github.com/tailwindcss/tailwindcss/blob/next/stubs/defaultConfig.stub.js#L5) for a complete list of theme options.
+See the [theme configuration reference](#configuration-reference) or the [default theme](https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js#L5) for a complete list of theme options.
 
 ### Screens
 
@@ -85,7 +85,7 @@ module.exports = {
         // ...
         900: '#1a202c',
       },
-      
+
       // ...
     }
   }
@@ -169,11 +169,11 @@ You'll notice that using a key of `default` in the theme configuration created t
 
 To learn more about customizing a specific core plugin, visit the documentation for that plugin.
 
-For a complete reference of available theme properties and their default values, [see the default theme configuration](https://github.com/tailwindcss/tailwindcss/blob/next/stubs/defaultConfig.stub.js#L5).
+For a complete reference of available theme properties and their default values, [see the default theme configuration](https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js#L5).
 
 ## Customizing the default theme
 
-Out of the box, your project will automatically inherit the values from [the default theme configuration](https://github.com/tailwindcss/tailwindcss/blob/next/stubs/defaultConfig.stub.js#L5). If you would like to customize the default theme, you have a few different options depending on your goals.
+Out of the box, your project will automatically inherit the values from [the default theme configuration](https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js#L5). If you would like to customize the default theme, you have a few different options depending on your goals.
 
 ### Overriding the default theme
 

--- a/source/docs/upgrading-to-v1.blade.md
+++ b/source/docs/upgrading-to-v1.blade.md
@@ -340,7 +340,7 @@ Here is a complete list of the sections that been split into multiple sections:
 
 Note that in some cases (`position`, `whitespace`) the original section still exists, while in others (`flexbox`, `textStyle`), the original section has been completely removed.
 
-You should reference the new [default config file](https://github.com/tailwindcss/tailwindcss/blob/next/stubs/defaultConfig.stub.js) if you are ever unsure if you are making the right changes.
+You should reference the new [default config file](https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js) if you are ever unsure if you are making the right changes.
 
 The simplest way to make these changes is to just copy the value you were using for the old section (something like `['responsive']`) to all of the new sections that replace that section, but if you choose you can also use this as an opportunity to cull generated utilities you don't actually need.
 
@@ -1098,10 +1098,10 @@ For grays (note that `grey` has changed to `gray`):
 | --- | --- |
 | black | gray-900 |
 | grey-darkest | gray-800 |
-| grey-darker | gray-700 | 
-| grey-dark | gray-600 | 
+| grey-darker | gray-700 |
+| grey-dark | gray-600 |
 | grey | gray-500 |
-| grey-light | gray-400 | 
+| grey-light | gray-400 |
 | grey-lighter | gray-200 |
 | grey-lightest | gray-100 |
 
@@ -1110,10 +1110,10 @@ For other colors:
 | Old | New |
 | --- | --- |
 | {color}-darkest | {color}-900 |
-| {color}-darker | {color}-800 | 
-| {color}-dark | {color}-600 | 
+| {color}-darker | {color}-800 |
+| {color}-dark | {color}-600 |
 | {color} | {color}-500 |
-| {color}-light | {color}-400 | 
+| {color}-light | {color}-400 |
 | {color}-lighter | {color}-200 |
 | {color}-lightest | {color}-100 |
 


### PR DESCRIPTION
- Change URL references from next to master
- Set trim_trailing_whitespace to false for `*.md` files (otherwise linebreaks get broken on save via editorconfig plugins)