### PR TITLE
Mention keeping white as white

### DIFF
--- a/source/docs/upgrading-to-v1.blade.md
+++ b/source/docs/upgrading-to-v1.blade.md
@@ -1109,6 +1109,7 @@ For other colors:
 
 | Old | New |
 | --- | --- |
+| white | white |
 | {color}-darkest | {color}-900 |
 | {color}-darker | {color}-800 |
 | {color}-dark | {color}-600 |


### PR DESCRIPTION
This is probably not necessary for reasonable minded folk, but I followed the conversions idiomatically and ended up with `text-white-500` . I don't think an explicit sentence to say it has not changed is necessary, but just being in there might save people a few minutes.