### PR TITLE
add js to ember code example

### DIFF
--- a/source/docs/installation.blade.md
+++ b/source/docs/installation.blade.md
@@ -255,7 +255,7 @@ exports.config = {
 
 Add `tailwindcss` to the list of plugins you pass to [ember-cli-postcss](https://github.com/jeffjewiss/ember-cli-postcss):
 
-```
+```js
 // ember-cli-build.js 
 'use strict';
 


### PR DESCRIPTION
On the installation example page the Ember.js example is not syntax highlighting correctly. 

![image](https://user-images.githubusercontent.com/19712217/57896086-8f473b80-7814-11e9-82f5-98e7a9e69cb7.png)

Adding `js` to the code block fixes the issue