### PR TITLE
Proper npm command for upgrading to 1.0

### DIFF
--- a/source/docs/upgrading-to-v1.blade.md
+++ b/source/docs/upgrading-to-v1.blade.md
@@ -36,7 +36,7 @@ These changes affect all users, whether you are using Tailwind with PostCSS and 
 Install the latest version of Tailwind:
 
 ```bash
-npm install tailwindcss --save-dev
+npm install tailwindcss@1.0.0 --save-dev
 ```
 
 Or using Yarn:


### PR DESCRIPTION
Just using `npm install tailwindcss --save-dev` on an existing project which is what this guide is for won’t work — you’ll just get the latest version available for your version range.