### PR TITLE
Fix destructuring the colors object

### DIFF
--- a/source/docs/customizing-colors.blade.md
+++ b/source/docs/customizing-colors.blade.md
@@ -198,7 +198,7 @@ You could also use [destructuring](https://developer.mozilla.org/en-US/docs/Web/
 
 ```js
 // tailwind.config.js
-const { teal, orange, pink, ...colors } = require('tailwindcss/defaultTheme')
+const { colors: { teal, orange, pink, ...colors } } = require('tailwindcss/defaultTheme')
 
 module.exports = {
   theme: {


### PR DESCRIPTION
Destructuring should be used in the colors object, not theme, otherwise it will generate the colors classes twice.