### PR TITLE
Destructure escape function

### DIFF
--- a/source/docs/plugins.blade.md
+++ b/source/docs/plugins.blade.md
@@ -390,7 +390,7 @@ module.exports = {
     }
   },
   plugins: [
-    function({ addUtilities, config }) {
+    function({ addUtilities, config, e }) {
       const rotateUtilities = _.map(config('theme.rotate'), (value, key) => {
         return {
           [`.${e(`rotate-${key}`)}`]: {


### PR DESCRIPTION
The `e` function must be destructured in order to use it here.