### PR TITLE
use correct break-all wordbreak css

### DIFF
--- a/source/docs/word-break.blade.md
+++ b/source/docs/word-break.blade.md
@@ -18,7 +18,7 @@ description: "Utilities for controlling word breaks in an element."
     ],
     [
       '.break-all',
-      'word-break: normal;',
+      'word-break: break-all;',
       'Break whenever necessary, without trying to preserve whole words.',
     ],
     [


### PR DESCRIPTION
`break-all` sets the `word-break: break-all` styling as opposed to the `word-break: normal` the docs talk about