### PR TITLE
Update to v1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "postcss-cssnext": "^3.0.2",
     "prismjs": "^1.8.3",
     "stylefmt": "^6.0.0",
-    "tailwindcss": "^1.0.1",
+    "tailwindcss": "^1.0.2",
     "vue": "^2.6.10",
     "vue-template-compiler": "^2.6.10",
     "webpack-watch": "^0.2.0",

--- a/source/_layouts/documentation.blade.php
+++ b/source/_layouts/documentation.blade.php
@@ -128,7 +128,7 @@
         <nav id="nav" class="px-6 pt-6 overflow-y-auto text-base lg:text-sm lg:py-12 lg:pl-6 lg:pr-8 sticky?lg:h-(screen-16)">
           <div class="relative -mx-2 w-24 mb-8 lg:hidden">
             <select data-version-switcher class="appearance-none block bg-white pl-2 pr-8 py-1 text-gray-500 font-medium text-base focus:outline-none focus:text-gray-800">
-              <option value="v1">v1.0.1</option>
+              <option value="v1">v{{ $page->version }}</option>
               <option value="v0">v0.7.4</option>
             </select>
             <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-500">

--- a/source/_layouts/homepage.blade.php
+++ b/source/_layouts/homepage.blade.php
@@ -155,7 +155,7 @@
         <nav id="nav" class="px-6 pt-6 overflow-y-auto text-base lg:text-sm lg:py-12 lg:pl-6 lg:pr-8 sticky?lg:h-screen">
           <div class="relative -mx-2 w-24 mb-8 lg:hidden">
             <select data-version-switcher class="appearance-none block bg-transparent pl-2 pr-8 py-1 text-gray-500 font-medium text-base focus:outline-none focus:text-gray-800">
-              <option value="v1">v1.0.1</option>
+              <option value="v1">v{{ $page->version }}</option>
               <option value="v0">v0.7.4</option>
             </select>
             <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-500">


### PR DESCRIPTION
This PR updates tailwindcss to 1.0.2 and uses the same `$page->version` where needed.