### PR TITLE
Add note about interpolation of !important in Sass/SCSS

### DIFF
--- a/source/docs/functions-and-directives.blade.md
+++ b/source/docs/functions-and-directives.blade.md
@@ -120,6 +120,14 @@ If you'd like to `@@apply` an existing class and make it `!important`, simply ad
 }
 ```
 
+If you're using the Sass/SCSS preprocessor you need to use the interpolation to make the class `!important`:
+
+```scss
+.btn {
+  @@apply font-bold py-2 px-4 rounded #{!important};
+}
+```
+
 Note that `@@apply` **will not work** for inlining pseudo-class or responsive variants of another utility. Instead, apply the plain version of that utility into the appropriate pseudo-selector or a new media query:
 
 ```css

--- a/source/docs/functions-and-directives.blade.md
+++ b/source/docs/functions-and-directives.blade.md
@@ -120,7 +120,7 @@ If you'd like to `@@apply` an existing class and make it `!important`, simply ad
 }
 ```
 
-If you're using the Sass/SCSS preprocessor you need to use the interpolation to make the class `!important`:
+Note that if you're using Sass/SCSS, you'll need to use Sass' interpolation feature to get this to work:
 
 ```scss
 .btn {
@@ -128,7 +128,7 @@ If you're using the Sass/SCSS preprocessor you need to use the interpolation to 
 }
 ```
 
-Note that `@@apply` **will not work** for inlining pseudo-class or responsive variants of another utility. Instead, apply the plain version of that utility into the appropriate pseudo-selector or a new media query:
+It's important to understand that `@@apply` **will not work** for inlining pseudo-class or responsive variants of another utility. Instead, apply the plain version of that utility into the appropriate pseudo-selector or a new media query:
 
 ```css
 /* Won't work: */


### PR DESCRIPTION
As discussed in https://github.com/tailwindcss/tailwindcss/issues/993 this caveat is mentioned in the docs but on another page. This PR should improve ability to find this information.