### PR TITLE
Add note about Chrome placeholder bug to position docs

### DIFF
--- a/source/docs/position.blade.md
+++ b/source/docs/position.blade.md
@@ -95,7 +95,26 @@ Offsets are calculated relative to the element's normal position and the element
 
 Use `.absolute` to position an element *outside* of the normal flow of the document, causing neighboring elements to act as if the element doesn't exist.
 
-Offsets are calculated relative to the nearest parent that has a position other than `static`, and the element *will* act as a position reference for other absolutely positioned children.
+<div class="text-sm bg-blue-100 text-blue-700 font-semi-bold px-4 py-2 mb-4 rounded">
+  <div class="flex items-center">
+    <div class="mr-2">
+      <svg class="block text-blue-400 h-5 w-5" fill="currentColor" xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20">
+        <path fill-rule="evenodd" clip-rule="evenodd"
+          d="M16.432 15C14.387 9.893 12 8.547 12 6V3h.5a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5H8v3c0 2.547-2.387 3.893-4.432 9-.651 1.625-2.323 4 6.432 4s7.083-2.375 6.432-4zm-1.617 1.751c-.702.21-2.099.449-4.815.449s-4.113-.239-4.815-.449c-.249-.074-.346-.363-.258-.628.22-.67.635-1.828 1.411-3.121 1.896-3.159 3.863.497 5.5.497s1.188-1.561 1.824-.497a15.353 15.353 0 0 1 1.411 3.121c.088.265-.009.553-.258.628z" />
+      </svg>
+    </div>
+    <div>
+      <p class="font-semibold">A bug in Chrome places input placeholders above all other elements similar to z-index. To
+        prevent this, add <span class="font-bold">.z-10</span> or higher to any absolutely positioned elements that
+        should sit on top of
+        all siblings.</p>
+    </div>
+  </div>
+</div>
+
+Offsets are calculated relative to the nearest parent that has a position other than `static`, and the element _will_
+act as a position reference for other absolutely positioned children.
 
 @component('_partials.code-sample')
 
@@ -147,7 +166,26 @@ Offsets are calculated relative to the nearest parent that has a position other 
 
 Use `.fixed` to position an element relative to the browser window.
 
-Offsets are calculated relative to the viewport and the element *will* act as a position reference for absolutely positioned children.
+<div class="text-sm bg-blue-100 text-blue-700 font-semi-bold px-4 py-2 mb-4 rounded">
+  <div class="flex items-center">
+    <div class="mr-2">
+      <svg class="block text-blue-400 h-5 w-5" fill="currentColor" xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20">
+        <path fill-rule="evenodd" clip-rule="evenodd"
+          d="M16.432 15C14.387 9.893 12 8.547 12 6V3h.5a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5H8v3c0 2.547-2.387 3.893-4.432 9-.651 1.625-2.323 4 6.432 4s7.083-2.375 6.432-4zm-1.617 1.751c-.702.21-2.099.449-4.815.449s-4.113-.239-4.815-.449c-.249-.074-.346-.363-.258-.628.22-.67.635-1.828 1.411-3.121 1.896-3.159 3.863.497 5.5.497s1.188-1.561 1.824-.497a15.353 15.353 0 0 1 1.411 3.121c.088.265-.009.553-.258.628z" />
+      </svg>
+    </div>
+    <div>
+      <p class="font-semibold">A bug in Chrome places input placeholders above all other elements similar to z-index. To
+        prevent this, add <span class="font-bold">.z-10</span> or higher to any fixed elements that should sit on top of
+        all
+        siblings.</p>
+    </div>
+  </div>
+</div>
+
+Offsets are calculated relative to the viewport and the element _will_ act as a position reference for absolutely
+positioned children.
 
 @component('_partials.code-sample')
 <div class="rounded-b overflow-hidden max-w-md mx-auto mt-4 mb-4">


### PR DESCRIPTION
This adds a note about Chrome's placeholder bug pertaining to absolute and fixed positioned elements with a recommended quick fix.

There is a bug in Chrome that places placeholders above all other elements as if it has a higher z-index. This causes them to sit on top of fixed elements when scrolling past. A quick fix for that is to explicitly set the z-index of fixed elements to anything over 0. With Tailwind, we can use `.z-10` to achieve this. It's hacky, but worth noting.

This PR adds a note to the `Absolute` and `Fixed` section of the docs explaining the hack.