### PR TITLE
Refine purgecss defaultExtractor regex for vuejs

### DIFF
--- a/source/docs/controlling-file-size.blade.md
+++ b/source/docs/controlling-file-size.blade.md
@@ -62,7 +62,7 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
   ],
 
   // Include any special characters you're using in this regular expression
-  defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []
+  defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]*[A-Za-z0-9-_/]/g) || []
 })
 
 module.exports = {

--- a/source/docs/controlling-file-size.blade.md
+++ b/source/docs/controlling-file-size.blade.md
@@ -92,7 +92,7 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
 The way it works is intentionally very "dumb". It doesn't try to parse your HTML and look for class attributes or dynamically execute your JavaScript — it simply looks for any strings in the entire file that match this regular expression:
 
 ```js
-/[A-Za-z0-9-_:/]+/g
+/[A-Za-z0-9-_:/]*[A-Za-z0-9-_/]/g
 ```
 
 That means that **it is important to avoid dynamically creating class strings in your templates with string concatenation**, otherwise Purgecss won't know to preserve those classes.
@@ -120,8 +120,8 @@ If you are using any other special characters in your class names, make sure to 
 For example, if you have customized Tailwind to create classes like `w-50%`, you'll want to add `%` to the regular expression:
 
 ```diff
-- /[A-Za-z0-9-_:/]+/g
-+ /[A-Za-z0-9-_:/%]+/g
+- /[A-Za-z0-9-_:/]*[A-Za-z0-9-_/]/g
++ /[A-Za-z0-9-_:/%]*[A-Za-z0-9-_/%]/g
 ```
 
 <hr class="my-16">

--- a/source/docs/controlling-file-size.blade.md
+++ b/source/docs/controlling-file-size.blade.md
@@ -85,7 +85,7 @@ Purgecss uses "extractors" to determine what strings in your templates are class
 ```js
 const purgecss = require('@fullhuman/postcss-purgecss')({
   // ...
-  defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []
+  defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]*[A-Za-z0-9-_/]/g) || []
 })
 ```
 


### PR DESCRIPTION
A Vue.js component can have the following attribute: `:class="{ invisible: someCondition }"` (sometimes even enforce by some linters)

With the current suggested regex `[A-Za-z0-9-_:/]+`, the whole `invisible:` word is interpreted as a class and the `invisible` class will be stripped away.
Changing the regex to prevent the `:` from being at the last position solves this issue: `[A-Za-z0-9-_:/]*[A-Za-z0-9-_/]`

I am not aware of any tailwind class ending with `:` (which this MR would break) and I think that someone generating such classes intentionally should be skilled enough to also adapt this regex to its usecase :-)