### PR TITLE
Fixed misleading usage of outline-0

### DIFF
--- a/source/components.blade.md
+++ b/source/components.blade.md
@@ -16,10 +16,10 @@ Instead, you're encouraged work [utility-first](/docs/utility-first) and [extrac
 @component('_partials.code-sample', ['class' => 'p-8 bg-white'])
 <div class="max-w-sm mx-auto">
   <p class="text-sm mb-2 text-gray-600">Simple form input component</p>
-  <input class="bg-white focus:outline-0 focus:shadow-outline border border-gray-300 rounded-lg py-2 px-4 block w-full appearance-none leading-normal" type="email" placeholder="jane@example.com">
+  <input class="bg-white focus:outline-none focus:shadow-outline border border-gray-300 rounded-lg py-2 px-4 block w-full appearance-none leading-normal" type="email" placeholder="jane@example.com">
 </div>
 @slot('code')
-<input class="bg-white focus:outline-0 focus:shadow-outline border border-gray-300 rounded-lg py-2 px-4 block w-full appearance-none leading-normal" type="email" placeholder="jane@example.com">
+<input class="bg-white focus:outline-none focus:shadow-outline border border-gray-300 rounded-lg py-2 px-4 block w-full appearance-none leading-normal" type="email" placeholder="jane@example.com">
 @endslot
 @endcomponent
 


### PR DESCRIPTION
In [one example there is `focus:outline-0`](https://tailwindcss.com/components) used instead of [the official `focus:outline-none`](https://tailwindcss.com/docs/outline/#app). I have changed it and verified locally it works as expected.

The preview of the change on Netlify: [here](https://deploy-preview-260--elated-stonebraker-70896a.netlify.com/components).