### PR TITLE
Refactor <a> css in header example

### DIFF
--- a/source/components/navigation.blade.md
+++ b/source/components/navigation.blade.md
@@ -75,14 +75,14 @@ Here are a few examples to help you get an idea of how to build components like 
       </button>
     </div>
     <div class="w-full block flex-grow lg:flex lg:items-center lg:w-auto">
-      <div class="text-sm lg:flex-grow">
-        <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-200 hover:text-white mr-4">
+      <div class="text-sm lg:flex-grow block mt-4 lg:inline-block lg:mt-0 text-teal-200 hover:text-white">
+        <a href="#responsive-header" class="mr-4">
           Docs
         </a>
-        <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-200 hover:text-white mr-4">
+        <a href="#responsive-header" class="mr-4">
           Examples
         </a>
-        <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-200 hover:text-white">
+        <a href="#responsive-header">
           Blog
         </a>
       </div>


### PR DESCRIPTION
Refactor common css classes for the <a> tags in the responsive header example.