### PR TITLE
Added flexbox items order to core plugins list

### DIFF
--- a/source/docs/configuration.blade.md
+++ b/source/docs/configuration.blade.md
@@ -386,6 +386,7 @@ Here's a list of every core plugin for reference:
 | `objectFit` | The `object-fit` utilities like `object-cover` |
 | `objectPosition` | The `object-position` utilities like `object-center` |
 | `opacity` | The `opacity` utilities like `opacity-50` |
+| `order` | The flexbox `order` utilities like `order-last` |
 | `outline` | The `outline` utilities like `outline-none` |
 | `overflow` | The `overflow` utilities like `overflow-hidden` |
 | `padding` | The `padding` utilities like `py-12` |


### PR DESCRIPTION
This adds the `order` to the list of core plugins on the Configuration page.
