### PR TITLE
Fix "Next Lesson" link

### DIFF
--- a/source/course/optimizing-for-production.blade.md
+++ b/source/course/optimizing-for-production.blade.md
@@ -7,7 +7,7 @@ hideTableOfContents: true
 vimeoId: 347913742
 prevUrl: "/course/customizing-your-design-system"
 prev: "Customizing Your Design System"
-nextUrl: "/course/coming-soon"
+nextUrl: "/course/structuring-a-basic-card"
 next: "Designing an Image Card"
 downloadHd: https://player.vimeo.com/external/347913742.hd.mp4?s=a11b07205e245781f68daecd67a931ab13ed0e34&profile_id=169&download=1
 downloadSd: https://player.vimeo.com/external/347913742.sd.mp4?s=04e006d7b8305d7d894a4499e30420dbaecf6465&profile_id=165&download=1


### PR DESCRIPTION
The "Next Lesson" link on the "Optimizing for Production" screencast still points to the "We're still working on this one!" page even though the content is already available.