### PR TITLE
Fix broken link to spacing customization page

### DIFF
--- a/source/docs/theme.blade.md
+++ b/source/docs/theme.blade.md
@@ -412,3 +412,6 @@ All of these keys are also available under the `theme.extend` key to enable [ext
 | `textColor` | Values for the `text-color` property |
 | `width` | Values for the `width` property |
 | `zIndex` | Values for the `z-index` property |
+
+
+

--- a/source/docs/theme.blade.md
+++ b/source/docs/theme.blade.md
@@ -131,7 +131,7 @@ module.exports = {
 
 By default, these values are inherited by the `padding`, `margin`, `negativeMargin`, `width`, and `height` core plugins.
 
-To learn more, see the [spacing customization documentation](/docs/spacing).
+To learn more, see the [spacing customization documentation](/docs/customizing-spacing).
 
 ### Core plugins
 
@@ -412,6 +412,3 @@ All of these keys are also available under the `theme.extend` key to enable [ext
 | `textColor` | Values for the `text-color` property |
 | `width` | Values for the `width` property |
 | `zIndex` | Values for the `z-index` property |
-
-
-


### PR DESCRIPTION
This PR fixes an incorrect link on the "Theme Configuration" page.  The current link is redirecting to `/docs/padding` rather than going directly to `/docs/customizing-spacing`.