### PR TITLE
Fixed 404 link to default theme config

### DIFF
--- a/source/docs/theme.blade.md
+++ b/source/docs/theme.blade.md
@@ -40,13 +40,13 @@ module.exports = {
 }
 ```
 
-We provide a sensible [default theme](https://github.com/tailwindcss/tailwindcss/blob/next/stubs/defaultConfig.stub.js#L5) with a very generous set of values to get you started, but don't be afraid to change it or extend; you're encouraged to customize it as much as you need to to fit the goals of your design.
+We provide a sensible [default theme](https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js#L5) with a very generous set of values to get you started, but don't be afraid to change it or extend; you're encouraged to customize it as much as you need to to fit the goals of your design.
 
 ## Theme structure
 
 The `theme` object contains keys for `screens`, `colors`, and `spacing`, as well as a key for each customizable [core plugin](/docs/core-plugins).
 
-See the [theme configuration reference](#configuration-reference) or the [default theme](https://github.com/tailwindcss/tailwindcss/blob/next/stubs/defaultConfig.stub.js#L5) for a complete list of theme options.
+See the [theme configuration reference](#configuration-reference) or the [default theme](https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js#L5) for a complete list of theme options.
 
 ### Screens
 
@@ -169,11 +169,11 @@ You'll notice that using a key of `default` in the theme configuration created t
 
 To learn more about customizing a specific core plugin, visit the documentation for that plugin.
 
-For a complete reference of available theme properties and their default values, [see the default theme configuration](https://github.com/tailwindcss/tailwindcss/blob/next/stubs/defaultConfig.stub.js#L5).
+For a complete reference of available theme properties and their default values, [see the default theme configuration](https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js#L5).
 
 ## Customizing the default theme
 
-Out of the box, your project will automatically inherit the values from [the default theme configuration](https://github.com/tailwindcss/tailwindcss/blob/next/stubs/defaultConfig.stub.js#L5). If you would like to customize the default theme, you have a few different options depending on your goals.
+Out of the box, your project will automatically inherit the values from [the default theme configuration](https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js#L5). If you would like to customize the default theme, you have a few different options depending on your goals.
 
 ### Overriding the default theme
 


### PR DESCRIPTION
Replaced links to the defaultConfig.stub.js#5 as the stubs folder doesn't exist on the Next branch, so I pointed the links to the master. Either that, or add in the stubs or remove the references to the default theme settings.