### PR TITLE
Plugins on configuration page need extra brackets

### DIFF
--- a/source/docs/configuration.blade.md
+++ b/source/docs/configuration.blade.md
@@ -151,9 +151,9 @@ The `plugins` section allows you to register third-party plugins with Tailwind t
 // tailwind.config.js
 module.exports = {
   plugins: [
-    require('tailwindcss-transforms'),
-    require('tailwindcss-transitions'),
-    require('tailwindcss-border-gradients'),
+    require('tailwindcss-transforms')(),
+    require('tailwindcss-transitions')(),
+    require('tailwindcss-border-gradients')(),
   ],
 }
 ```


### PR DESCRIPTION
I have tested all of these plugins and they all need the brackets to work.