### PR TITLE
Fixed backgroundColors typo

### DIFF
--- a/source/docs/configuration.blade.md
+++ b/source/docs/configuration.blade.md
@@ -135,7 +135,7 @@ The `variants` section lets you control which [variants](/docs/pseudo-class-vari
 module.exports = {
   variants: {
     appearance: ['responsive'],
-    backgroundColors: ['responsive', 'hover', 'focus'],
+    backgroundColor: ['responsive', 'hover', 'focus'],
     fill: [],
   },
 }


### PR DESCRIPTION
I guess this got left behind from the v1 migration.