### PR TITLE
Use more inclusive language in documentation

### DIFF
--- a/navigation.php
+++ b/navigation.php
@@ -186,7 +186,7 @@ return [
             'Using a custom color palette'  => '/course/coming-soon',
             'Adding custom utilities'  => '/course/coming-soon',
             'Working with third-party plugins'  => '/course/coming-soon',
-            'Writing your own simple plugin'  => '/course/coming-soon',
+            'Writing your own plugin'  => '/course/coming-soon',
         ]
     ],
     'Resources' => [

--- a/source/components.blade.md
+++ b/source/components.blade.md
@@ -9,13 +9,13 @@ titleBorder: true
 
 Unlike many other CSS frameworks, **Tailwind doesn't include any component classes like `form-input`, `btn`, `card`, or `navbar`**.
 
-Tailwind is a CSS framework for implementing custom designs, and even a component as simple as a button can look completely different from one site to another, so providing opinionated component styles that you'd end up wanting to override anyways would only make the development experience more frustrating.
+Tailwind is a CSS framework for implementing custom designs, and even a component as small as a button can look completely different from one site to another, so providing opinionated component styles that you'd end up wanting to override anyways would only make the development experience more frustrating.
 
 Instead, you're encouraged work [utility-first](/docs/utility-first) and [extract your own components](/docs/extracting-components) when you start to notice common patterns in your UI.
 
 @component('_partials.code-sample', ['class' => 'p-8 bg-white'])
 <div class="max-w-sm mx-auto">
-  <p class="text-sm mb-2 text-gray-600">Simple form input component</p>
+  <p class="text-sm mb-2 text-gray-600">Form input component</p>
   <input class="bg-white focus:outline-none focus:shadow-outline border border-gray-300 rounded-lg py-2 px-4 block w-full appearance-none leading-normal" type="email" placeholder="jane@example.com">
 </div>
 @slot('code')

--- a/source/components/alerts.blade.md
+++ b/source/components/alerts.blade.md
@@ -5,7 +5,7 @@ description: Examples of building alert components with Tailwind CSS.
 titleBorder: true
 ---
 
-Tailwind doesn't include pre-designed alert components out of the box, but they're easy to build using existing utilities.
+Tailwind doesn't include pre-designed alert components out of the box, but they can be built using existing utilities.
 
 Here are a few examples to help you get an idea of how to build components like this using Tailwind.
 

--- a/source/components/buttons.blade.md
+++ b/source/components/buttons.blade.md
@@ -5,7 +5,7 @@ description: Examples of building buttons with Tailwind CSS.
 titleBorder: true
 ---
 
-Tailwind doesn't include pre-designed button styles out of the box, but they're easy to build using existing utilities.
+Tailwind doesn't include pre-designed button styles out of the box, but they can be built using existing utilities.
 
 Here are a few examples to help you get an idea of how to build components like this using Tailwind.
 

--- a/source/components/cards.blade.md
+++ b/source/components/cards.blade.md
@@ -5,7 +5,7 @@ description: Examples of building card components with Tailwind CSS.
 titleBorder: true
 ---
 
-Tailwind doesn't include pre-designed card components out of the box, but they're easy to build using existing utilities.
+Tailwind doesn't include pre-designed card components out of the box, but they can be built using existing utilities.
 
 Here are a few examples to help you get an idea of how to build components like this using Tailwind.
 

--- a/source/components/forms.blade.md
+++ b/source/components/forms.blade.md
@@ -5,7 +5,7 @@ description: Examples of building forms with Tailwind CSS.
 titleBorder: true
 ---
 
-Tailwind doesn't include purpose-built form control classes out of the box, but form controls are easy to style using existing utilities.
+Tailwind doesn't include purpose-built form control classes out of the box, but form controls are can be styled using existing utilities.
 
 Here are a few examples to help you get an idea of how to build components like this using Tailwind.
 

--- a/source/components/grids.blade.md
+++ b/source/components/grids.blade.md
@@ -5,7 +5,7 @@ description: Examples of building grid layouts with Tailwind CSS.
 titleBorder: true
 ---
 
-Tailwind doesn't include purpose-built grid classes out of the box, but grid layouts are simple to build using the existing [Flexbox](/docs/flexbox-display) and [width](/docs/width) utilities.
+Tailwind doesn't include purpose-built grid classes out of the box, but grid layouts can be built using the existing [Flexbox](/docs/flexbox-display) and [width](/docs/width) utilities.
 
 Here are a few examples to help you get an idea of how to build grids using Tailwind.
 

--- a/source/components/navigation.blade.md
+++ b/source/components/navigation.blade.md
@@ -5,7 +5,7 @@ description: Examples of building navigation components with Tailwind CSS.
 titleBorder: true
 ---
 
-Tailwind doesn't include pre-designed navigation components out of the box, but they're easy to build using existing utilities.
+Tailwind doesn't include pre-designed navigation components out of the box, but they can be built using existing utilities.
 
 Here are a few examples to help you get an idea of how to build components like this using Tailwind.
 

--- a/source/course/designing-a-badge.blade.md
+++ b/source/course/designing-a-badge.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.course-lesson
 title: "Designing a Badge"
-description: "Learn how to build and style a simple badge component."
+description: "Learn how to build and style a badge component."
 titleBorder: true
 hideTableOfContents: true
 vimeoId: 352533407

--- a/source/course/setting-up-tailwind-and-postcss.blade.md
+++ b/source/course/setting-up-tailwind-and-postcss.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.course-lesson
 title: "Setting up Tailwind and PostCSS"
-description: "Learn how to install Tailwind and get it compiling in a simple HTML project."
+description: "Learn how to install Tailwind and get it compiling in a small HTML project."
 titleBorder: true
 hideTableOfContents: true
 vimeoId: 345586861

--- a/source/docs/adding-base-styles.blade.md
+++ b/source/docs/adding-base-styles.blade.md
@@ -110,5 +110,5 @@ In general, it's simpler to add base styles to your project in CSS than it is to
 
 You should prefer a plugin if:
 
-- You want to publish your base styles publicly and make them easy for other users to install.
+- You want to publish your base styles publicly and make them available for other users to install.
 - You want to re-use your base styles across multiple projects in your company and prefer sharing JS dependencies instead of CSS dependencies.

--- a/source/docs/adding-base-styles.blade.md
+++ b/source/docs/adding-base-styles.blade.md
@@ -31,7 +31,7 @@ If you want to apply some global styling to the `html` or `body` elements, consi
 
 ## Using CSS
 
-If you want to apply some base styles to specific elements, the easiest way is to simply add them in your CSS.
+If you want to apply some base styles to specific elements, one way is to add them in your CSS.
 
 Define any of your own custom base styles directly after `@@tailwind base` and before `@@tailwind components` to avoid specificity issues:
 
@@ -106,7 +106,7 @@ Any styles you added using `addBase` will automatically be included in your `@@t
 
 ### When to use a plugin
 
-In general, it's simpler to add base styles to your project in CSS than it is to write a plugin.
+In general, it's less complex to add base styles to your project in CSS than it is to write a plugin.
 
 You should prefer a plugin if:
 

--- a/source/docs/adding-base-styles.blade.md
+++ b/source/docs/adding-base-styles.blade.md
@@ -7,7 +7,7 @@ titleBorder: true
 
 Base (or global) styles are the styles at the beginning of a stylesheet that set useful defaults for basic HTML elements like `<a>` tags, headings, etc. or apply opinionated resets like the popular [box-sizing reset](https://www.paulirish.com/2012/box-sizing-border-box-ftw/).
 
-Tailwind includes a useful set of base styles out of the box that we call [Preflight](/docs/preflight), which is really just [normalize.css](https://github.com/necolas/normalize.css/) plus a thin layer of additional more opinionated styles.
+Tailwind includes a useful set of base styles out of the box that we call [Preflight](/docs/preflight), which is essentially [normalize.css](https://github.com/necolas/normalize.css/) plus a thin layer of additional more opinionated styles.
 
 Preflight is a great starting point for most projects, but if you'd ever like to add your own additional base styles, here are some recommendations for doing it idiomatically.
 
@@ -15,7 +15,7 @@ Preflight is a great starting point for most projects, but if you'd ever like to
 
 ## Using classes in your HTML
 
-If you just want to apply some global styling to the `html` or `body` elements, consider just adding existing classes to those elements in your HTML instead of writing new CSS:
+If you want to apply some global styling to the `html` or `body` elements, consider adding existing classes to those elements in your HTML instead of writing new CSS:
 
 ```html
 <!doctype html>

--- a/source/docs/adding-new-utilities.blade.md
+++ b/source/docs/adding-new-utilities.blade.md
@@ -13,7 +13,7 @@ Deciding on the best way to extend a framework can be paralyzing, so here are so
 
 ## Using CSS
 
-The easiest way to add your own utilities to Tailwind is to simply add them to your CSS.
+One way to add your own utilities to Tailwind is to add them to your CSS.
 
 @component('_partials.tip-good')
 Add any custom utilities to the end of your CSS file
@@ -225,6 +225,6 @@ module.exports = {
 
 ```
 
-This can be a good choice if you want to publish your custom utilities as a library or make it easier to share them across multiple projects.
+This can be a good choice if you want to publish your custom utilities as a library or make them available to be shared across multiple projects.
 
 Learn more in the [utility plugin documentation](/docs/plugins#adding-utilities).

--- a/source/docs/background-color.blade.md
+++ b/source/docs/background-color.blade.md
@@ -126,7 +126,7 @@ Focus utilities can also be combined with responsive utilities by adding the res
 
 By default Tailwind makes the entire [default color palette](/docs/customizing-colors#default-color-palette) available as background colors.
 
-You can [customize your color palette](/docs/colors#customizing) by editing the `theme.colors` variable in your `tailwind.config.js` file, or customize just your background colors using the `theme.backgroundColor` section of your Tailwind config.
+You can [customize your color palette](/docs/colors#customizing) by editing the `theme.colors` variable in your `tailwind.config.js` file, or customize only your background colors using the `theme.backgroundColor` section of your Tailwind config.
 
 @component('_partials.customized-config', ['key' => 'theme.backgroundColor', 'usesTheme' => true])
 - ...theme('colors'),

--- a/source/docs/border-color.blade.md
+++ b/source/docs/border-color.blade.md
@@ -128,7 +128,7 @@ Focus utilities can also be combined with responsive utilities by adding the res
 
 By default Tailwind makes the entire [default color palette](/docs/customizing-colors#default-color-palette) available as border colors.
 
-You can [customize your color palette](/docs/colors#customizing) by editing the `theme.colors` variable in your `tailwind.config.js` file, or customize just your border colors using the `theme.borderColor` section of your Tailwind config.
+You can [customize your color palette](/docs/colors#customizing) by editing the `theme.colors` variable in your `tailwind.config.js` file, or customize only your border colors using the `theme.borderColor` section of your Tailwind config.
 
 @component('_partials.customized-config', ['key' => 'theme.borderColor', 'usesTheme' => true])
 - ...theme('colors'),

--- a/source/docs/configuration.blade.md
+++ b/source/docs/configuration.blade.md
@@ -325,7 +325,7 @@ module.exports = {
 }
 ```
 
-If you'd like to disable all of Tailwind's core plugins and simply use Tailwind as a tool for processing your own custom plugins, provide an empty array:
+If you'd like to disable all of Tailwind's core plugins and use Tailwind as a tool for processing your own custom plugins, provide an empty array:
 
 ```js
 // tailwind.config.js

--- a/source/docs/configuration.blade.md
+++ b/source/docs/configuration.blade.md
@@ -411,7 +411,7 @@ Here's a list of every core plugin for reference:
 
 It can often be useful to reference your configuration values in your own client-side JavaScript — for example to access some of your theme values when dynamically applying inline styles in a React or Vue component.
 
-To make this easy, Tailwind provides a `resolveConfig` helper you can use to generate a fully merged version of your configuration object:
+To do this, Tailwind provides a `resolveConfig` helper you can use to generate a fully merged version of your configuration object:
 
 ```js
 import resolveConfig from 'tailwindcss/resolveConfig'

--- a/source/docs/configuration.blade.md
+++ b/source/docs/configuration.blade.md
@@ -226,7 +226,7 @@ That means if you add your own responsive utility like this:
 }
 ```
 
-If you'd like to prefix your own utilities as well, just add the prefix to the class definition:
+If you'd like to prefix your own utilities as well, add the prefix to the class definition:
 
 ```css
 @responsive {
@@ -264,7 +264,7 @@ Now all of Tailwind's utility classes will be generated as `!important`:
 
 Note that any of your own custom utilities **will not** automatically be marked as `!important` by enabling this option.
 
-If you'd like to make your own utilities `!important`, just add `!important` to the end of each declaration yourself:
+If you'd like to make your own utilities `!important`, add `!important` to the end of each declaration yourself:
 
 ```css
 @responsive {

--- a/source/docs/configuring-variants.blade.md
+++ b/source/docs/configuring-variants.blade.md
@@ -287,7 +287,7 @@ Note that enabling all variants for all plugins will result in much bigger file 
 
 ## Using custom variants
 
-If you've written or installed a [plugin](/docs/plugins) that adds a new variant, you can enable that variant by including it in your variants configuration just like if it were a built-in variant.
+If you've written or installed a [plugin](/docs/plugins) that adds a new variant, you can enable that variant by including it in your variants configuration as if it were a built-in variant.
 
 For example, the [tailwindcss-interaction-variants plugin](https://github.com/benface/tailwindcss-interaction-variants) adds a `visited` variant (among others):
 

--- a/source/docs/controlling-file-size.blade.md
+++ b/source/docs/controlling-file-size.blade.md
@@ -89,7 +89,7 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
 })
 ```
 
-The way it works is intentionally very naive. It doesn't try to parse your HTML and look for class attributes or dynamically execute your JavaScript — it simply looks for any strings in the entire file that match this regular expression:
+The way it works is intentionally very naive. It doesn't try to parse your HTML and look for class attributes or dynamically execute your JavaScript — it looks for any strings in the entire file that match this regular expression:
 
 ```js
 /[\w-:/]+(?<!:)/g

--- a/source/docs/controlling-file-size.blade.md
+++ b/source/docs/controlling-file-size.blade.md
@@ -148,7 +148,7 @@ For example, if you have customized Tailwind to create classes like `w-50%`, you
 
 If you can't use Purgecss for one reason or another, you can also reduce Tailwind's footprint by removing unused values from [your configuration file](/docs/configuration).
 
-The default theme provides a very generous set of colors, breakpoints, sizes, margins, etc. to make sure that when you pull Tailwind down to prototype something, create a CodePen demo, or just try out the workflow, the experience is as enjoyable and fluid as possible.
+The default theme provides a very generous set of colors, breakpoints, sizes, margins, etc. to make sure that when you pull Tailwind down to prototype something, create a CodePen demo, or try out the workflow, the experience is as enjoyable and fluid as possible.
 
 We don't want you to have to go and write new CSS because we didn't provide enough padding helpers out of the box, or because you wanted to use an orange color scheme for your demo and we only gave you blue.
 

--- a/source/docs/customizing-colors.blade.md
+++ b/source/docs/customizing-colors.blade.md
@@ -114,7 +114,7 @@ This will generate classes like `bg-regal-blue` in addition to all of Tailwind's
 
 ## Overriding a default color
 
-If you'd like to override one of Tailwind's default colors but preserve the rest, simply provide the new values in the `theme.extend.colors` section of your `tailwind.config.js` file.
+If you'd like to override one of Tailwind's default colors but preserve the rest, provide the new values in the `theme.extend.colors` section of your `tailwind.config.js` file.
 
 For example, here we've replaced the default cool grays with a neutral gray palette:
 
@@ -194,7 +194,7 @@ module.exports = {
 }
 ```
 
-You could also use [destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) to simplify the above example if you're comfortable with it:
+You could also use [destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) in the above example if you're comfortable with it:
 
 ```js
 // tailwind.config.js

--- a/source/docs/customizing-colors.blade.md
+++ b/source/docs/customizing-colors.blade.md
@@ -169,7 +169,7 @@ module.exports = {
 
 ## Disabling a default color
 
-If you'd like to disable a default color because you aren't using it in your project, the easiest approach is to just build a new color palette that references the default theme.
+If you'd like to disable a default color because you aren't using it in your project, the easiest approach is to build a new color palette that references the default theme.
 
 For example, this `tailwind.config.js` file excludes teal, orange, and pink, but includes the rest of the default colors:
 

--- a/source/docs/customizing-colors.blade.md
+++ b/source/docs/customizing-colors.blade.md
@@ -245,7 +245,7 @@ module.exports = {
 }
 ```
 
-You could even define these colors using CSS custom properties (variables) to make it easy to switch themes on the client:
+You could even define these colors using CSS custom properties (variables) to make it possible to switch themes on the client:
 
 ```js
 // tailwind.config.js

--- a/source/docs/customizing-colors.blade.md
+++ b/source/docs/customizing-colors.blade.md
@@ -26,7 +26,7 @@ By default these colors are automatically shared by the `textColor`, `borderColo
 
 ### Nested object syntax
 
-You can define your colors as a simple list of key-value pairs as we've done above, or using a nested object notation where the nested keys are added to the base color name as modifiers:
+You can define your colors as a list of key-value pairs as we've done above, or using a nested object notation where the nested keys are added to the base color name as modifiers:
 
 ```js
 // tailwind.config.js

--- a/source/docs/extracting-components.blade.md
+++ b/source/docs/extracting-components.blade.md
@@ -298,7 +298,7 @@ Now you'd apply two classes any time you needed to style a button:
 @endslot
 @endcomponent
 
-This makes it easy to change the shared styles in one place by just editing the `.btn` class.
+This makes it possible to change the shared styles in one place by just editing the `.btn` class.
 
 It also allows you to add new one-off button styles without being forced to create a new component class or duplicate the shared styles:
 

--- a/source/docs/extracting-components.blade.md
+++ b/source/docs/extracting-components.blade.md
@@ -298,7 +298,7 @@ Now you'd apply two classes any time you needed to style a button:
 @endslot
 @endcomponent
 
-This makes it possible to change the shared styles in one place by just editing the `.btn` class.
+This makes it possible to change the shared styles in one place by editing the `.btn` class.
 
 It also allows you to add new one-off button styles without being forced to create a new component class or duplicate the shared styles:
 

--- a/source/docs/extracting-components.blade.md
+++ b/source/docs/extracting-components.blade.md
@@ -351,7 +351,7 @@ module.exports = {
 }
 ```
 
-This can be a good choice if you want to publish your Tailwind components as a library or make it easier to share components across multiple projects.
+This can be a good choice if you want to publish your Tailwind components as a library or make it available to share components across multiple projects.
 
 Learn more in the [component plugin documentation](/docs/plugins#adding-components).
 

--- a/source/docs/extracting-components.blade.md
+++ b/source/docs/extracting-components.blade.md
@@ -139,7 +139,7 @@ The above example uses [Vue](https://vuejs.org/v2/guide/components.html), but th
 
 ## Extracting CSS components with @@apply
 
-For small components like buttons and form elements, creating a template partial or JavaScript component can often feel too heavy compared to a simple CSS class.
+For small components like buttons and form elements, creating a template partial or JavaScript component can often feel too heavy compared to a CSS class.
 
 In these situations, you can use Tailwind's `@apply` directive to easily extract common utility patterns to CSS component classes.
 

--- a/source/docs/fill.blade.md
+++ b/source/docs/fill.blade.md
@@ -16,7 +16,7 @@ description: "Utilities for styling the fill of SVG elements."
 
 ## Usage
 
-Use `.fill-current` to set the fill color of an SVG to the current text color. This makes it easy to set an element's fill color by combining this class with an existing [text color utility](/docs/text-color).
+Use `.fill-current` to set the fill color of an SVG to the current text color. This makes it possible to set an element's fill color by combining this class with an existing [text color utility](/docs/text-color).
 
 Useful for styling icon sets like [Zondicons](http://www.zondicons.com/) that are drawn entirely with fills.
 

--- a/source/docs/font-family.blade.md
+++ b/source/docs/font-family.blade.md
@@ -105,7 +105,7 @@ By default Tailwind provides three font family utilities: a cross-browser sans-s
 + 'body': ['Open Sans', ...],
 @endcomponent
 
-Font families can be specified as an array or as a simple comma-delimited string:
+Font families can be specified as an array or as a comma-delimited string:
 
 ```js
 {

--- a/source/docs/functions-and-directives.blade.md
+++ b/source/docs/functions-and-directives.blade.md
@@ -100,7 +100,7 @@ Any rules inlined with `@@apply` will have `!important` **removed** by default t
 }
 ```
 
-If you'd like to `@@apply` an existing class and make it `!important`, simply add `!important` to the end of the declaration:
+If you'd like to `@@apply` an existing class and make it `!important`, add `!important` to the end of the declaration:
 
 
 ```css

--- a/source/docs/installation.blade.md
+++ b/source/docs/installation.blade.md
@@ -86,7 +86,7 @@ Learn more about configuration Tailwind in the [configuration documentation](/do
 
 ### Using Tailwind CLI
 
-For simple projects or just giving Tailwind a spin, you can use the Tailwind CLI tool to process your CSS:
+For smaller projects or just giving Tailwind a spin, you can use the Tailwind CLI tool to process your CSS:
 
 ```bash
 npx tailwind build styles.css -o output.css

--- a/source/docs/opacity.blade.md
+++ b/source/docs/opacity.blade.md
@@ -97,7 +97,7 @@ For more information about Tailwind's responsive design features, check out the 
 
 ### Opacity Scale
 
-By default Tailwind provides five opacity utilities based on a simple numeric scale. You change, add, or remove these by editing the `theme.opacity` section of your Tailwind config.
+By default Tailwind provides five opacity utilities based on a numeric scale. You change, add, or remove these by editing the `theme.opacity` section of your Tailwind config.
 
 @component('_partials.customized-config', ['key' => 'theme.opacity'])
   '0': '0',

--- a/source/docs/placeholder-color.blade.md
+++ b/source/docs/placeholder-color.blade.md
@@ -100,7 +100,7 @@ Focus utilities can also be combined with responsive utilities by adding the res
 
 By default Tailwind makes the entire [default color palette](/docs/customizing-colors#default-color-palette) available as placeholder colors.
 
-You can [customize your color palette](/docs/colors#customizing) by editing `theme.colors` in your `tailwind.config.js` file, or customize just your placeholder colors in the `theme.textColor` section.
+You can [customize your color palette](/docs/colors#customizing) by editing `theme.colors` in your `tailwind.config.js` file, or customize your placeholder colors in the `theme.textColor` section.
 
 @component('_partials.customized-config', ['key' => 'theme'])
 - placeholderColor: theme => theme('colors'),

--- a/source/docs/plugins.blade.md
+++ b/source/docs/plugins.blade.md
@@ -7,7 +7,7 @@ titleBorder: true
 
 <h2 style="font-size: 0" class="invisible m-0 -mb-6">Overview</h2>
 
-At their simplest, plugins are just functions that register new styles for Tailwind to inject into the user's stylesheet. That means that to get started authoring your own plugin, all you need to do is add an anonymous function to the `plugins` list in your config file:
+Plugins are functions that register new styles for Tailwind to inject into the user's stylesheet. That means that to get started authoring your own plugin, all you need to do is add an anonymous function to the `plugins` list in your config file:
 
 ```js
 // tailwind.config.js
@@ -560,7 +560,7 @@ It often makes sense for a plugin to expose its own options that the user can co
 
 The best way to accomplish this is to claim your own key in the user's `theme` and `variants` configuration and ask them to provide any options there so you can access them with the `theme` and `variants` functions.
 
-For example, here's a plugin *(extracted to its own module)* for creating simple gradient utilities that accepts the gradients and variants to generate as options:
+For example, here's a plugin *(extracted to its own module)* for creating gradient utilities that accepts the gradients and variants to generate as options:
 
 ```js
 // ./plugins/gradients.js
@@ -607,7 +607,7 @@ module.exports = {
 
 Each of `addUtilities`, `addComponents`, and `addBase` expect CSS rules written as JavaScript objects. Tailwind uses the same sort of syntax you might recognize from CSS-in-JS libraries like [Emotion](https://emotion.sh/docs/object-styles), and is powered by [postcss-js](https://github.com/postcss/postcss-js) under the hood.
 
-Consider this simple CSS rule:
+Consider this CSS rule:
 
 ```css
 .card {
@@ -738,7 +738,7 @@ The callback receives an object that can be destructured into the following part
 
 ### Basic variants
 
-If you want to add a simple variant that only needs to change the selector, use the `modifySelectors` helper.
+If you want to add a variant that only needs to change the selector, use the `modifySelectors` helper.
 
 The `modifySelectors` helper accepts a function that receives an object that can be destructured into the following parts:
 

--- a/source/docs/plugins.blade.md
+++ b/source/docs/plugins.blade.md
@@ -421,7 +421,7 @@ This plugin would generate the following CSS:
 
 Be careful to only escape content you actually want to escape; don't pass the leading `.` in a class name or the `:` at the beginning pseudo-classes like `:hover` or `:focus` or those characters will be escaped.
 
-Additionally, because CSS has rules about the characters a class name can *start* with (a class can't start with a number, but it can contain one), it's a good idea to escape your complete class name (not just the user-provided portion) or you may end up with unnecessary escape sequences:
+Additionally, because CSS has rules about the characters a class name can *start* with (a class can't start with a number, but it can contain one), it's a good idea to escape your complete class name (not only the user-provided portion) or you may end up with unnecessary escape sequences:
 
 ```js
 // Will unnecessarily escape `1`
@@ -508,7 +508,7 @@ module.exports = {
 }
 ```
 
-Note that the `theme` function is really just a shortcut for using the `config` function to access the theme section of the user's config:
+Note that the `theme` function is a shortcut for using the `config` function to access the theme section of the user's config:
 
 ```js
 // These are equivalent
@@ -711,7 +711,7 @@ addComponents([
 
 ## Adding variants
 
-The `addVariant` function allows you to register your own custom [variants](/docs/pseudo-class-variants) that can be used just like the built-in hover, focus, active, etc. variants.
+The `addVariant` function allows you to register your own custom [variants](/docs/pseudo-class-variants) that can be used like the built-in hover, focus, active, etc. variants.
 
 To add a new variant, call the `addVariant` function, passing in the name of your custom variant, and a callback that modifies the affected CSS rules as needed.
 

--- a/source/docs/plugins.blade.md
+++ b/source/docs/plugins.blade.md
@@ -478,7 +478,7 @@ prefix('.btn-blue .w-1\/4 > h1.text-xl + a .bar')
 
 The `config`, `theme`, and `variants` functions allow you to ask for a value from the user's Tailwind configuration using dot notation, providing a default value if that path doesn't exist.
 
-For example, this simplified version of the built-in [container](/docs/container) plugin uses the `theme` function to get the user's configured breakpoints:
+For example, this version of the built-in [container](/docs/container) plugin uses the `theme` function to get the user's configured breakpoints:
 
 ```js
 // tailwind.config.js
@@ -534,7 +534,7 @@ Use unprefixed utilities to target mobile, and override them at larger breakpoin
 addUtilities(newUtilities, variants('customPlugin'))
 ```
 
-Since `variants` could simply be a global list of variants to configure for every plugin in the whole project, using the `variants()` function lets you easily respect the user's configuration without reimplementing that logic yourself.
+Since `variants` could be a global list of variants to configure for every plugin in the whole project, using the `variants()` function lets you easily respect the user's configuration without reimplementing that logic yourself.
 
 ```js
 // tailwind.config.js
@@ -732,7 +732,7 @@ module.exports = {
 
 The callback receives an object that can be destructured into the following parts:
 
-- `modifySelectors`, a helper function to simplify adding basic variants
+- `modifySelectors`, a helper function for adding basic variants
 - `separator`, the user's configured [separator string](/docs/configuration#separator)
 - `container`, a [PostCSS Container](http://api.postcss.org/Container.html) containing all of the rules the variant is being applied to, for creating complex variants
 
@@ -745,7 +745,7 @@ The `modifySelectors` helper accepts a function that receives an object that can
 - `selector`, the complete unmodified selector for the current rule
 - `className`, the class name of the current rule *with the leading dot removed*
 
-The function you pass to `modifySelectors` should simply return the modified selector.
+The function you pass to `modifySelectors` should return the modified selector.
 
 For example, a `first-child` variant plugin could be written like this:
 
@@ -766,7 +766,7 @@ module.exports = {
 
 ### Complex variants
 
-If you need to do anything beyond simply modifying selectors (like changing the actual rule declarations, or wrapping the rules in another at-rule), you'll need to use the `container` instance.
+If you need to do anything beyond modifying selectors (like changing the actual rule declarations, or wrapping the rules in another at-rule), you'll need to use the `container` instance.
 
 Using the `container` instance, you can traverse all of the rules within a given module or `@variants` block and manipulate them however you like using the standard PostCSS API.
 

--- a/source/docs/preflight.blade.md
+++ b/source/docs/preflight.blade.md
@@ -133,7 +133,7 @@ If you ever need to make one of these elements `inline` instead of `block`, simp
 
 ## Border styles are reset globally
 
-In order to make it easy to add a border by simply adding the `border` class, Tailwind overrides the default border styles for all elements with the following rules:
+In order to add a border by adding the `border` class, Tailwind overrides the default border styles for all elements with the following rules:
 
 ```css
 *,

--- a/source/docs/preflight.blade.md
+++ b/source/docs/preflight.blade.md
@@ -7,7 +7,7 @@ titleBorder: true
 
 <h2 style="font-size: 0" class="invisible m-0 -mb-6">Overview</h2>
 
-Built on top of [normalize.css](https://github.com/necolas/normalize.css/), Preflight is a set of base styles for Tailwind projects that are designed to smooth over cross-browser inconsistencies and make it easier for you work within the constraints of your design system.
+Built on top of [normalize.css](https://github.com/necolas/normalize.css/), Preflight is a set of base styles for Tailwind projects that are designed to smooth over cross-browser inconsistencies and make it possible for you work within the constraints of your design system.
 
 Tailwind automatically injects these styles when you include `@@tailwind base` in your CSS:
 
@@ -19,7 +19,7 @@ Tailwind automatically injects these styles when you include `@@tailwind base` i
 @@tailwind utilities;
 ```
 
-While most of the styles in Preflight are meant to go unnoticed — they simply make things behave more like you'd expect them to — some are more opinionated and can be surprising when you first encounter them.
+While most of the styles in Preflight are meant to go unnoticed — they are designed to make things behave more like you'd expect them to — some are more opinionated and can be surprising when you first encounter them.
 
 For a complete reference of all the styles applied by Preflight, [see the stylesheet](https://unpkg.com/tailwindcss/dist/base.css).
 
@@ -123,7 +123,7 @@ object {
 
 This helps to avoid unexpected alignment issues that you often run into using the browser default of `display: inline`.
 
-If you ever need to make one of these elements `inline` instead of `block`, simply use the `inline` utility:
+If you ever need to make one of these elements `inline` instead of `block`, use the `inline` utility:
 
 ```html
 <img class="inline" src="..." alt="...">
@@ -161,7 +161,7 @@ When you run into situations like this, you can work around them by overriding t
 
 ## Extending Preflight
 
-If you'd like to add your own base styles on top of Preflight, simply add them to your CSS after `@@tailwind base`:
+If you'd like to add your own base styles on top of Preflight, add them to your CSS after `@@tailwind base`:
 
 ```css
 @@tailwind base;

--- a/source/docs/pseudo-class-variants.blade.md
+++ b/source/docs/pseudo-class-variants.blade.md
@@ -468,7 +468,7 @@ For more information, see the [@@variants directive documentation](/docs/functio
 
 You can create your own variants for any pseudo-classes Tailwind doesn't include by default by writing a custom variant plugin.
 
-For example, this simple plugin adds support for the `disabled` pseudo-class variant:
+For example, this plugin adds support for the `disabled` pseudo-class variant:
 
 ```js
 // tailwind.config.js

--- a/source/docs/quick-start.blade.md
+++ b/source/docs/quick-start.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.documentation
 title: "Quick Start"
-description: "Get up and running with Tailwind CSS in just a few minutes."
+description: "Get up and running with Tailwind CSS."
 titleBorder: true
 ---
 

--- a/source/docs/release-notes.blade.md
+++ b/source/docs/release-notes.blade.md
@@ -67,7 +67,7 @@ module.exports = {
 }
 ```
 
-This makes it a lot easier to know what values are custom for your project and which ones are built in to Tailwind by default, and in general keeps your config file a lot simpler and more manageable.
+This makes it a lot easier to know what values are custom for your project and which ones are built in to Tailwind by default, and in general keeps your config file a lot more manageable.
 
 Learn more about the new configuration format in [the configuration documentation](/docs/configuration).
 

--- a/source/docs/release-notes.blade.md
+++ b/source/docs/release-notes.blade.md
@@ -67,7 +67,7 @@ module.exports = {
 }
 ```
 
-This makes it a lot easier to know what values are custom for your project and which ones are built in to Tailwind by default, and in general keeps your config file a lot more manageable.
+This makes it clearer to know what values are custom for your project and which ones are built in to Tailwind by default, and in general keeps your config file a lot more manageable.
 
 Learn more about the new configuration format in [the configuration documentation](/docs/configuration).
 
@@ -101,7 +101,7 @@ module.exports = {
 }
 ```
 
-The new breakpoints are more practical to work with and make it a bit easier to avoid annoying compromises in your responsive designs.
+The new breakpoints are more practical to work with and are designed to avoid annoying compromises in your responsive designs.
 
 New to responsive design with Tailwind? Check out our [responsive design documentation](/docs/responsive-design) to learn more.
 

--- a/source/docs/responsive-design.blade.md
+++ b/source/docs/responsive-design.blade.md
@@ -34,7 +34,7 @@ To add a utility but only have it take effect at a certain breakpoint, all you n
 
 This works for **every utility class in the framework**, which means you can change literally anything at a given breakpoint — even things like letter spacing or cursor styles.
 
-Here's a simple example of a marketing page component that uses a stacked layout on small screens, and a side-by-side layout on larger screens *(resize your browser to see it in action)*:
+Here's an example of a marketing page component that uses a stacked layout on small screens, and a side-by-side layout on larger screens *(resize your browser to see it in action)*:
 
 @component('_partials.code-sample', ['class' => 'p-8'])
 <div class="md:flex">
@@ -66,7 +66,7 @@ By default, Tailwind uses a mobile first breakpoint system, similar to what you 
 
 What this means is that unprefixed utilities (like `uppercase`) take effect on all screen sizes, while prefixed utilities (like `md:uppercase`) only take effect at the specified breakpoint *and above*.
 
-Here's a simple example that cycles through several background colors at different breakpoints *(resize your browser to see the background color change)*:
+Here's an example that cycles through several background colors at different breakpoints *(resize your browser to see the background color change)*:
 
 @component('_partials.code-sample', ['class' => 'p-0'])
 <div class="h-20 w-20 mx-auto rounded-lg bg-red-500 sm:bg-green-500 md:bg-blue-500 lg:bg-pink-500 xl:bg-teal-500"></div>

--- a/source/docs/responsive-design.blade.md
+++ b/source/docs/responsive-design.blade.md
@@ -52,7 +52,7 @@ Here's an example of a marketing page component that uses a stacked layout on sm
 Here's how the example above works:
 
 - By default, the outer `div` is `display: block`, but by adding the `md:flex` utility, it becomes `display: flex` on medium screens and larger.
-- When the parent is a flex container, we want to make sure the image never shrinks, so we've added `md:flex-shrink-0` to prevent shrinking on medium screens and larger. Technically we could have just used `flex-shrink-0` since it would do nothing on smaller screens, but since it only matters on `md` screens, it's a good idea to make that clear in the class name.
+- When the parent is a flex container, we want to make sure the image never shrinks, so we've added `md:flex-shrink-0` to prevent shrinking on medium screens and larger. Technically we could have used `flex-shrink-0` since it would do nothing on smaller screens, but since it only matters on `md` screens, it's a good idea to make that clear in the class name.
 - On small screens the image is automatically full width by default. On medium screens and up, we've constrained that width to a fixed size using `md:w-56`.
 - On small screens, the content section uses `mt-4` to add some margin between the content and the image. This margin isn't necessary in the horizontal layout, so we've used `md:mt-0` to undo that margin, and used `md:ml-6` to add some left margin instead.
 

--- a/source/docs/responsive-design.blade.md
+++ b/source/docs/responsive-design.blade.md
@@ -75,7 +75,7 @@ Here's an example that cycles through several background colors at different bre
 @endslot
 @endcomponent
 
-Throughout the documentation, you'll often see this interactive widget which we use to quickly demonstrate how some code would look on different screen sizes without forcing you to resize the browser — simply click the device icons at the top to see how the code below would render at that breakpoint:
+Throughout the documentation, you'll often see this interactive widget which we use to quickly demonstrate how some code would look on different screen sizes without forcing you to resize the browser — click the device icons at the top to see how the code below would render at that breakpoint:
 
 @component('_partials.responsive-code-sample')
 @slot('none')

--- a/source/docs/stroke.blade.md
+++ b/source/docs/stroke.blade.md
@@ -16,7 +16,7 @@ description: "Utilities for styling the stroke of SVG elements."
 
 ## Usage
 
-Use `.stroke-current` to set the stroke color of an SVG to the current text color. This makes it easy to set an element's stroke color by combining this class with an existing [text color utility](/docs/text-color).
+Use `.stroke-current` to set the stroke color of an SVG to the current text color. This makes it possible to set an element's stroke color by combining this class with an existing [text color utility](/docs/text-color).
 
 Useful for styling icon sets like [Feather](https://feathericons.com/) that are drawn entirely with strokes.
 

--- a/source/docs/text-color.blade.md
+++ b/source/docs/text-color.blade.md
@@ -129,7 +129,7 @@ Focus utilities can also be combined with responsive utilities by adding the res
 
 By default Tailwind makes the entire [default color palette](/docs/customizing-colors#default-color-palette) available as text colors.
 
-You can [customize your color palette](/docs/colors#customizing) by editing `theme.colors` in your `tailwind.config.js` file, or customize just your text colors in the `theme.textColor` section.
+You can [customize your color palette](/docs/colors#customizing) by editing `theme.colors` in your `tailwind.config.js` file, or customize only your text colors in the `theme.textColor` section.
 
 @component('_partials.customized-config', ['key' => 'theme'])
 - textColor: theme => theme('colors'),

--- a/source/docs/theme.blade.md
+++ b/source/docs/theme.blade.md
@@ -364,7 +364,7 @@ module.exports = {
 }
 ```
 
-Since the entire `theme` object is available in your CSS using the [theme function](/docs/functions-and-directives#theme), you might also add a key just to be able to reference it in your CSS.
+Since the entire `theme` object is available in your CSS using the [theme function](/docs/functions-and-directives#theme), you might also add a key to be able to reference it in your CSS.
 
 ## Configuration reference
 

--- a/source/docs/upgrading-to-v1.blade.md
+++ b/source/docs/upgrading-to-v1.blade.md
@@ -342,7 +342,7 @@ Note that in some cases (`position`, `whitespace`) the original section still ex
 
 You should reference the new [default config file](https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js) if you are ever unsure if you are making the right changes.
 
-The simplest way to make these changes is to copy the value you were using for the old section (something like `['responsive']`) to all of the new sections that replace that section, but if you choose you can also use this as an opportunity to cull generated utilities you don't actually need.
+One way to make these changes is to copy the value you were using for the old section (something like `['responsive']`) to all of the new sections that replace that section, but if you choose you can also use this as an opportunity to cull generated utilities you don't actually need.
 
 For example, if you never use the responsive variants of `antialiased` or `subpixel-antialiased`, you could set `fontSmoothing` to `[]` while still using `['responsive']` for `fontStyle`, `textDecoration`, and `textTransform`.
 
@@ -549,7 +549,7 @@ Next, update any sections that were referencing the `colors` variable using the 
 
 In v0.x, `require('tailwindcss/defaultConfig')` returned a function that returned the default config when invoked.
 
-In v1.0, it simply returns the object:
+In v1.0, it returns the object:
 
 ```diff
 - let defaultConfig = require('tailwindcss/defaultConfig')()
@@ -799,7 +799,7 @@ If you chose override our base styles and give lists a default style, you can us
 + <ul class="list-none p-0"><!-- ... --></ul>
 ```
 
-Again, **if you are using our `preflight` styles unmodified (you probably are), you can simply remove `list-reset` from your markup and nothing will change**.
+Again, **if you are using our `preflight` styles unmodified (you probably are), you can remove `list-reset` from your markup and nothing will change**.
 
 This change only really affects you if you are _not_ using our `preflight` styles, or overriding our global list reset.
 

--- a/source/docs/upgrading-to-v1.blade.md
+++ b/source/docs/upgrading-to-v1.blade.md
@@ -719,7 +719,7 @@ The `config()` helper function that Tailwind makes available to your CSS files h
   }
 ```
 
-A simple find and replace across your CSS files that switches `config(` to `theme(` should do it.
+A find and replace across your CSS files that switches `config(` to `theme(` should do it.
 
 <h3 class="no-toc">6. Explicitly style any headings</h3>
 

--- a/source/docs/upgrading-to-v1.blade.md
+++ b/source/docs/upgrading-to-v1.blade.md
@@ -11,7 +11,7 @@ So while there's not a ton of exciting new features, you can at least be excited
 
 ## Upgrade steps for all users
 
-These changes affect all users, whether you are using Tailwind with PostCSS and your own custom config file, or just using the default config file or CDN.
+These changes affect all users, whether you are using Tailwind with PostCSS and your own custom config file, or using the default config file or CDN.
 
 1. [Update Tailwind](#1-update-tailwind)
 2. [Update your config file](#2-update-your-config-file)
@@ -132,7 +132,7 @@ Your config file should look generally like this at this point:
 
 "Modules" was a word we just kinda grabbed because we needed *something*, and we wanted to use that section of the config to both specify variants and disable modules if necessary.
 
-Now that all of Tailwind's internal "modules" are actually just core plugins, I've decided to deprecate this terminology entirely, and make this section of the config purely about configuring variants for core plugins.
+Now that all of Tailwind's internal "modules" are now core plugins, I've decided to deprecate this terminology entirely, and make this section of the config purely about configuring variants for core plugins.
 
 After making this change, your config file should look like this:
 
@@ -342,7 +342,7 @@ Note that in some cases (`position`, `whitespace`) the original section still ex
 
 You should reference the new [default config file](https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js) if you are ever unsure if you are making the right changes.
 
-The simplest way to make these changes is to just copy the value you were using for the old section (something like `['responsive']`) to all of the new sections that replace that section, but if you choose you can also use this as an opportunity to cull generated utilities you don't actually need.
+The simplest way to make these changes is to copy the value you were using for the old section (something like `['responsive']`) to all of the new sections that replace that section, but if you choose you can also use this as an opportunity to cull generated utilities you don't actually need.
 
 For example, if you never use the responsive variants of `antialiased` or `subpixel-antialiased`, you could set `fontSmoothing` to `[]` while still using `['responsive']` for `fontStyle`, `textDecoration`, and `textTransform`.
 
@@ -386,7 +386,7 @@ This change was made to make it possible to disable other core plugins where `va
 
 #### 2.8. Remove the `container` plugin from `plugins` and move any configuration to `theme`
 
-In v1.0, the `container` plugin is a core plugin just like `padding`, `margin`, etc. and should not be listed in your `plugins` section:
+In v1.0, the `container` plugin is a core plugin like `padding`, `margin`, etc. and should not be listed in your `plugins` section:
 
 ```diff
   let defaultConfig = require('tailwindcss/defaultConfig')()
@@ -634,7 +634,7 @@ If you haven't customized the `opacity` values, remove them:
 
 We will not change any of this configuration outside of a major version bump, so you are totally safe to depend on inheriting the default values.
 
-The way your configuration is merged with the defaults is designed to be very intuitive and mostly just work, but for the curious:
+The way your configuration is merged with the defaults is designed to be intuitive and mostly just work, but for the curious:
 
 - `prefix` is replaced
 - `separator` is replaced
@@ -681,7 +681,7 @@ If you keep your config file in a different folder, you'll still need to provide
 
 <p class="italic font-normal text-gray-600 mt-4">Impact: All users, Effort: Trivial</p>
 
-One of the new features in v1.0 is the ability for plugins to register base styles. As a result, our `preflight` styles are actually just another core plugin now, and the general "bucket" for base styles has been renamed from `preflight` to `base`.
+One of the new features in v1.0 is the ability for plugins to register base styles. As a result, our `preflight` styles are actually now another core plugin, and the general "bucket" for base styles has been renamed from `preflight` to `base`.
 
 Replace any instance of `@@tailwind preflight` in your CSS files with `@@tailwind base`:
 
@@ -735,7 +735,7 @@ By using the user agent styles for headings, we also made it far too easy to acc
 
 By unstyling headings by default, we make it a lot easier to avoid this pitfall by ensuring that any size or weight you set is explicit and intentional.
 
-This change might not affect you at all if you are already specifying a font-weight and font-size on all your headings, but if you aren't, you just need to assign an explicit size and weight wherever it's missing:
+This change might not affect you at all if you are already specifying a font-weight and font-size on all your headings, but if you aren't, you’ll need to assign an explicit size and weight wherever it's missing:
 
 ```diff
 - <h1>Manage Account<h1>
@@ -785,7 +785,7 @@ ol {
 
 <p class="italic font-normal text-gray-600 mt-4">Impact: Moderate, Effort: Low</p>
 
-Since lists are now unstyled by default, `.list-reset` has been removed. You technically don't need to change anything, but you're encouraged to remove any usage of it as it's now just dead code:
+Since lists are now unstyled by default, `.list-reset` has been removed. You technically don't need to change anything, but you're encouraged to remove any usage of it as it's now dead code:
 
 ```diff
 - <ul class="list-reset"><!-- ... --></ul>

--- a/source/docs/using-with-preprocessors.blade.md
+++ b/source/docs/using-with-preprocessors.blade.md
@@ -113,7 +113,7 @@ Won't work, `@@import` statements must come first
 @@import "./custom-utilities.css";
 ```
 
-You can solve this by putting your `@@tailwind` declarations each in their own file. To make this easy, we provide separate files for each `@@tailwind` declaration with the framework itself that you can import directly from `node_modules`.
+You can solve this by putting your `@@tailwind` declarations each in their own file. To do this, we provide separate files for each `@@tailwind` declaration with the framework itself that you can import directly from `node_modules`.
 
 @component('_partials.tip-good')
 Import our provided CSS files

--- a/source/docs/using-with-preprocessors.blade.md
+++ b/source/docs/using-with-preprocessors.blade.md
@@ -290,7 +290,7 @@ Won't work, Less doesn't realise it's a media query
 }
 ```
 
-Instead, use a regular media query along with the `theme()` function to reference your screen sizes, or simply don't nest your `@@screen` directives.
+Instead, use a regular media query along with the `theme()` function to reference your screen sizes, or don't nest your `@@screen` directives.
 
 @component('_partials.tip-good')
 Use a regular media query and theme()
@@ -379,7 +379,7 @@ Won't work, Stylus doesn't realise it's a media query
 }
 ```
 
-Instead, use a regular media query along with the `theme()` function to reference your screen sizes, or simply don't nest your `@@screen` directives.
+Instead, use a regular media query along with the `theme()` function to reference your screen sizes, or don't nest your `@@screen` directives.
 
 @component('_partials.tip-good')
 Use a regular media query and theme()

--- a/source/docs/using-with-preprocessors.blade.md
+++ b/source/docs/using-with-preprocessors.blade.md
@@ -5,9 +5,9 @@ description: "A guide to using Tailwind with common CSS preprocessors like Sass,
 titleBorder: true
 ---
 
-Since Tailwind is a PostCSS plugin, there's nothing stopping you from using it with Sass, Less, Stylus, or other preprocessors, just like you can with other PostCSS plugins like [Autoprefixer](https://github.com/postcss/autoprefixer).
+Since Tailwind is a PostCSS plugin, there's nothing stopping you from using it with Sass, Less, Stylus, or other preprocessors, like you can with other PostCSS plugins like [Autoprefixer](https://github.com/postcss/autoprefixer).
 
-It's important to note that **you don't need to use a preprocessor with Tailwind** — you typically write very little CSS on a Tailwind project anyways so using a preprocessor just isn't as beneficial as it would be in a project where you write a lot of custom CSS.
+It's important to note that **you don't need to use a preprocessor with Tailwind** — you typically write very little CSS on a Tailwind project anyways so using a preprocessor probably isn't as beneficial as it would be in a project where you write a lot of custom CSS.
 
 This guide only exists as a reference for people who need to or would like to integrate Tailwind with a preprocessor for one reason or another.
 

--- a/source/docs/utility-first.blade.md
+++ b/source/docs/utility-first.blade.md
@@ -132,7 +132,7 @@ But using utility classes has a few important advantages over inline styles:
 
 - **Designing with constraints**. Using inline styles, every value is a magic number. With utilities, you're choosing styles from a predefined [design system](/docs/theme), which makes it much easier to build visually consistent UIs.
 - **Responsive design**. You can't use media queries in inline styles, but you can use Tailwind's [responsive utilities](/docs/responsive-design) to build fully responsive interfaces easily.
-- **Pseudo-classes**. Inline styles can't target states like hover or focus, but Tailwind's [pseudo-class variants](/docs/pseudo-class-variants) make it easy to style those states with utility classes.
+- **Pseudo-classes**. Inline styles can't target states like hover or focus, but Tailwind's [pseudo-class variants](/docs/pseudo-class-variants) make it possible to style those states with utility classes.
 
 This component is fully responsive and includes a button with hover styles, and is built entirely with utility classes:
 

--- a/source/docs/utility-first.blade.md
+++ b/source/docs/utility-first.blade.md
@@ -116,7 +116,7 @@ Now I know what you're thinking, _"this is an atrocity, what a horrible mess!"_ 
 
 But once you've actually built something this way, you'll quickly notice some really important benefits:
 
-- **You aren't wasting energy inventing class names**. No more adding silly class names like `sidebar-inner-wrapper` just to be able to style something, and no more agonizing over the perfect abstract name for something that's really just a flex container.
+- **You aren't wasting energy inventing class names**. No more adding silly class names like `sidebar-inner-wrapper` to be able to style something, and no more agonizing over the perfect abstract name for something that's really just a flex container.
 - **Your CSS stops growing**. Using a traditional approach, your CSS files get bigger every time you add a new feature. With utilities, everything is reusable so you rarely need to write new CSS.
 - **Making changes feels safer**. CSS is global and you never know what you're breaking when you make a change. Classes in your HTML are local, so you can change them without worrying about something else breaking.
 
@@ -124,9 +124,9 @@ When you realize how productive you can be working exclusively in HTML with pred
 
 ---
 
-## Why not just use inline styles?
+## Why not use inline styles?
 
-A common reaction to this approach is wondering, "isn't this just inline styles?" and in some ways it is — you're applying styles directly to elements instead of assigning them a class name and then styling that class.
+A common reaction to this approach is wondering, "isn't this inline styles?" and in some ways it is — you're applying styles directly to elements instead of assigning them a class name and then styling that class.
 
 But using utility classes has a few important advantages over inline styles:
 

--- a/source/docs/utility-first.blade.md
+++ b/source/docs/utility-first.blade.md
@@ -130,7 +130,7 @@ A common reaction to this approach is wondering, "isn't this inline styles?" and
 
 But using utility classes has a few important advantages over inline styles:
 
-- **Designing with constraints**. Using inline styles, every value is a magic number. With utilities, you're choosing styles from a predefined [design system](/docs/theme), which makes it much easier to build visually consistent UIs.
+- **Designing with constraints**. Using inline styles, every value is a magic number. With utilities, you're choosing styles from a predefined [design system](/docs/theme), which allows you to build visually consistent UIs.
 - **Responsive design**. You can't use media queries in inline styles, but you can use Tailwind's [responsive utilities](/docs/responsive-design) to build fully responsive interfaces easily.
 - **Pseudo-classes**. Inline styles can't target states like hover or focus, but Tailwind's [pseudo-class variants](/docs/pseudo-class-variants) make it possible to style those states with utility classes.
 
@@ -189,7 +189,7 @@ This is easily solved by [extracting components](/docs/extracting-components), e
 @endslot
 @endcomponent
 
-Aside from that, maintaining a utility-first CSS project turns out to be a lot easier than maintaining a large CSS codebase, simply because HTML is so much easier to maintain than CSS. Large companies like GitHub, Heroku, Kickstarter, Twitch, Segment, and more are using this approach with great success.
+Aside from that, maintaining a utility-first CSS project often turns out to be a lot easier than maintaining a large CSS codebase, mainly because HTML is generally easier to maintain than CSS. Large companies like GitHub, Heroku, Kickstarter, Twitch, Segment, and more are using this approach with great success.
 
 If you'd like to hear about others' experiences with this approach, check out the following resources:
 

--- a/source/index.blade.md
+++ b/source/index.blade.md
@@ -34,9 +34,9 @@ If you're sick of fighting the framework, overriding unwanted styles, and battli
 
 ## Responsive to the core
 
-Every Tailwind utility also comes with responsive variants, making it extremely easy to build responsive interfaces without resorting to custom CSS.
+Every Tailwind utility also comes with responsive variants, so that you can build responsive interfaces without resorting to custom CSS.
 
-Tailwind uses an intuitive `{screen}:` prefix that makes it easy to notice responsive classes in your markup while keeping the original class name recognizable and intact.
+Tailwind uses an intuitive `{screen}:` prefix that makes it easier to notice responsive classes in your markup while keeping the original class name recognizable and intact.
 
 @component('_partials.responsive-code-sample')
 @slot('none')
@@ -89,7 +89,7 @@ Tailwind uses an intuitive `{screen}:` prefix that makes it easy to notice respo
 
 While you can do a *lot* with just utility classes, as a project grows it can be useful to codify common patterns into higher level abstractions.
 
-Tailwind provides tools for [extracting component classes](/docs/extracting-components) from repeated utility patterns, making it easy to update multiple instances of a component from one place:
+Tailwind provides tools for [extracting component classes](/docs/extracting-components) from repeated utility patterns, making it possible to update multiple instances of a component from one place:
 
 @component('_partials.code-sample', ['lang' => 'html', 'class' => 'text-center'])
 <button class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">

--- a/source/index.blade.md
+++ b/source/index.blade.md
@@ -87,7 +87,7 @@ Tailwind uses an intuitive `{screen}:` prefix that makes it easier to notice res
 
 ## Component-friendly
 
-While you can do a *lot* with just utility classes, as a project grows it can be useful to codify common patterns into higher level abstractions.
+While you can do a *lot* with utility classes alone, as a project grows it can be useful to codify common patterns into higher level abstractions.
 
 Tailwind provides tools for [extracting component classes](/docs/extracting-components) from repeated utility patterns, making it possible to update multiple instances of a component from one place:
 

--- a/source/index.blade.md
+++ b/source/index.blade.md
@@ -36,7 +36,7 @@ If you're sick of fighting the framework, overriding unwanted styles, and battli
 
 Every Tailwind utility also comes with responsive variants, so that you can build responsive interfaces without resorting to custom CSS.
 
-Tailwind uses an intuitive `{screen}:` prefix that makes it easier to notice responsive classes in your markup while keeping the original class name recognizable and intact.
+Tailwind uses a `{screen}:` prefix that is designed to be easier to notice responsive classes in your markup while keeping the original class name recognizable and intact.
 
 @component('_partials.responsive-code-sample')
 @slot('none')

--- a/source/resources.blade.md
+++ b/source/resources.blade.md
@@ -46,7 +46,7 @@ We use Unsplash any time we need example photos in the documentation, like for o
 
 [![](/img/resources/undraw.png)](https://undraw.co/)
 
-They're easy to customize and perfect for landing pages, empty states, and more.
+They can be customized and are perfect for landing pages, empty states, and more.
 
 [Find free illustrations on unDraw &rarr;](https://undraw.co/)
 
@@ -56,7 +56,7 @@ They're easy to customize and perfect for landing pages, empty states, and more.
 
 ### Heroicons UI
 
-[Heroicons UI](https://github.com/sschoger/heroicons-ui) is a free SVG icon set created by [Steve Schoger](https://twitter.com/steveschoger). They're pre-optimized and easy to use directly in your HTML where you can customize them using Tailwind's color and sizing utilities.
+[Heroicons UI](https://github.com/sschoger/heroicons-ui) is a free SVG icon set created by [Steve Schoger](https://twitter.com/steveschoger). They're pre-optimized and can be used directly in your HTML where you can customize them using Tailwind's color and sizing utilities.
 
 [![](/img/resources/heroicons-ui.png)](https://github.com/sschoger/heroicons-ui)
 

--- a/source/resources.blade.md
+++ b/source/resources.blade.md
@@ -6,7 +6,7 @@ titleBorder: true
 hideTableOfContents: false
 ---
 
-We think Tailwind is an amazing CSS framework, but you need more than just a CSS framework to produce visually awesome work.
+We think Tailwind is an amazing CSS framework, but you need more than a CSS framework alone to produce visually awesome work.
 
 Here are some resources that can help you take your Tailwind projects to the next level.
 


### PR DESCRIPTION
Taking inspiration from @carolstran, this PR changes some occurrences of some condescending language (“simply”, “easy”, “just” etc…) from the documentation. I haven’t changed _all_ instances and possible some changes don’t make complete sense so some input or suggestions would be nice.