### PR TITLE
Adds missing word

### DIFF
--- a/source/docs/border-width.blade.md
+++ b/source/docs/border-width.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.documentation
 title: "Border Width"
-description: "Utilities for controlling the width an element's borders."
+description: "Utilities for controlling the width of an element's borders."
 features:
   responsive: true
   customizable: true


### PR DESCRIPTION
Border width docs are missing a word in the description