### PR TITLE
Fix 'Ember.js' entry indentation in installation page

### DIFF
--- a/source/docs/installation.blade.md
+++ b/source/docs/installation.blade.md
@@ -277,12 +277,12 @@ exports.config = {
 }
 ```
 
-#### Ember.js
+### Ember.js
 
 Add `tailwindcss` to the list of plugins you pass to [ember-cli-postcss](https://github.com/jeffjewiss/ember-cli-postcss):
 
 ```js
-// ember-cli-build.js 
+// ember-cli-build.js
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');


### PR DESCRIPTION
<img width="253" alt="Screen Shot 2019-11-07 at 3 29 34 PM" src="https://user-images.githubusercontent.com/4951004/68393200-3974a000-0174-11ea-8f6d-ae98a194563a.png">

The Ember entry is using an `h4` tag, and isn't visible in the sidebar