### PR TITLE
Update group-hover example

### DIFF
--- a/source/docs/pseudo-class-variants.blade.md
+++ b/source/docs/pseudo-class-variants.blade.md
@@ -341,7 +341,7 @@ You can control whether `group-hover` variants are enabled for a utility in the 
 module.exports = {
   // ...
   variants: {
-    borderColor: ['responsive', 'hover', 'focus', 'group-hover'],
+    textColor: ['responsive', 'hover', 'focus', 'group-hover'],
   },
 }
 ```


### PR DESCRIPTION
It was confusing for users discovering the docs. 

The HTML example uses `group-hover` on `textColor` utilities, but the configuration right below adds `group-hover` on `borderColor`, which is unrelated.

![](https://i.imgur.com/JrQ0hUR.png)