### PR TITLE
Improve documentation about resolveConfig with corePlugins

### DIFF
--- a/source/docs/configuration.blade.md
+++ b/source/docs/configuration.blade.md
@@ -468,3 +468,19 @@ fullConfig.theme.screens.md
 fullConfig.theme.boxShadow['2xl']
 // => '0 25px 50px -12px rgba(0, 0, 0, 0.25)'
 ```
+
+Note: `resolveConfig` will give you the full configugration object with all plugins. If you have whitelisted/blacklisted some `corePlugins` you have to filter the theme properties if you only want enabled ones:
+
+```js
+// if you also need sreens values and another custom property
+const wantedKeys = fullConfig.corePlugins.concat(["screens", "myCustomProp"])
+const myTheme = wantedKeys.reduce((theme, key) => {
+    if (fullConfig.theme.hasOwnProperty(key)) {
+        return {
+            ...theme,
+            [key]: fullConfig.theme[key]
+        };
+    }
+    return theme;
+}, {});
+```


### PR DESCRIPTION
We may think that `resolveConfig` will provide the very final tailwindcss theme but it doesn't filter the "enabled/disabled" `corePlugins`.

This PR notices that in the documentation and add an example of how to get the wanted one.