### PR TITLE
Update installation.blade.md to fix possible security issue

### DIFF
--- a/source/docs/installation.blade.md
+++ b/source/docs/installation.blade.md
@@ -61,7 +61,7 @@ If you're using `postcss-import` (or a tool that uses it under the hood, such as
 If you'd like to customize your Tailwind installation, you can generate a config file for your project using the Tailwind CLI utility included when you install the `tailwindcss` npm package:
 
 ```bash
-npx tailwind init
+npx --no-install tailwind init
 ```
 
 This will create a minimal `tailwind.config.js` file at the root of your project:
@@ -89,10 +89,10 @@ Learn more about configuring Tailwind in the [configuration documentation](/docs
 For simple projects or just giving Tailwind a spin, you can use the Tailwind CLI tool to process your CSS:
 
 ```bash
-npx tailwind build styles.css -o output.css
+npx --no-install tailwind build styles.css -o output.css
 ```
 
-Use the `npx tailwind help build` command to learn more about the various CLI options.
+Use the `npx --no-install tailwind help build` command to learn more about the various CLI options.
 
 ### Using Tailwind with PostCSS
 


### PR DESCRIPTION
`tailwind` refers to a different package in the npm registry. It is dangerous to attempt to run `npx tailwind` without prior explicit warning that people should install `tailwindcss` first. The general public uses npx to execute npm packages without having to install them locally, therefor running `npx tailwind init` results in unexpected behaviour. The proof is that there already are issues on the web of users failing to run it.

Using this alias is rather unfortunate and I see three possible solutions:
1) update the commands to not attempt to install a package if it's not available locally `--no-install` as in this PR
2) warn people explicitly that `tailwind` is just an alias and that `tailwindcss` must be installed first
3) use `tailwindcss` alias for the executable instead of `tailwind`

https://github.com/tailwindcss/discuss/issues/304