### PR TITLE
Update grid-auto-flow docs to show correct underlying CSS declarations

### DIFF
--- a/source/docs/grid-auto-flow.blade.md
+++ b/source/docs/grid-auto-flow.blade.md
@@ -12,15 +12,15 @@ description: "Utilities for controlling how elements in a grid are auto-placed."
     ],
     [
       '.grid-flow-col',
-      'grid-auto-flow: col;',
+      'grid-auto-flow: column;',
     ],
     [
       '.grid-flow-row-dense',
-      'grid-auto-flow: row-dense;',
+      'grid-auto-flow: row dense;',
     ],
     [
       '.grid-flow-col-dense',
-      'grid-auto-flow: col-dense;',
+      'grid-auto-flow: column dense;',
     ],
   ]
 ])


### PR DESCRIPTION
The docs show the CSS values generated by `.grid-flow-col`, `.grid-flow-row-dense`, and `.grid-flow-col-dense` as `col`, `row-dense`, and `col-dense`, when they're actually `column`, `row dense`, and `column dense`.

Tailwind [generates that CSS correctly](https://github.com/tailwindcss/tailwindcss/blob/61e5ac5f98468decf453711bcfa9460752f1ba27/src/plugins/gridAutoFlow.js#L6-L8), it's just the docs that show the invalid values.