### PR TITLE
Fix config import

### DIFF
--- a/source/docs/configuration.blade.md
+++ b/source/docs/configuration.blade.md
@@ -476,7 +476,7 @@ To make this easy, Tailwind provides a `resolveConfig` helper you can use to gen
 
 ```js
 import resolveConfig from 'tailwindcss/resolveConfig'
-import tailwindConfig from './tailwind.config.js'
+import * as tailwindConfig from './tailwind.config.js'
 
 const fullConfig = resolveConfig(tailwindConfig)
 


### PR DESCRIPTION
When using webpack/babel, to import the default export of a commonjs module in ES6, you must use the syntax `import * as foo from 'module.js'`.