### PR TITLE
Add leading-{size} to purge whitelist

### DIFF
--- a/source/_purge-whitelist.blade.php
+++ b/source/_purge-whitelist.blade.php
@@ -335,6 +335,14 @@ leading-snug
 leading-normal
 leading-relaxed
 leading-loose
+leading-3
+leading-4
+leading-5
+leading-6
+leading-7
+leading-8
+leading-9
+leading-10
 
 opacity-100
 opacity-75


### PR DESCRIPTION
Looks like `leading-{size}` is currently purged from the CSS: https://tailwindcss.com/docs/line-height/#fixed-line-heights

I'm not seeing any `leading-{size}` in https://tailwindcss.com/assets/build/css/main.css?id=da35c01d0ae8bad54242