### PR TITLE
Update CDN link

### DIFF
--- a/source/docs/installation.blade.md
+++ b/source/docs/installation.blade.md
@@ -333,7 +333,7 @@ To get the most out of Tailwind, you really should [install it via npm](#1-insta
 To pull in Tailwind for quick demos or just giving the framework a spin, grab the latest default configuration build via CDN:
 
 ```html
-<link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
+<link href="https://unpkg.com/tailwindcss@^1.2/dist/tailwind.min.css" rel="stylesheet">
 ```
 
 Note that while the CDN build is large *(27kb compressed, 348kb raw)*, **it's not representative of the sizes you see when including Tailwind as part of your build process**.


### PR DESCRIPTION
If there is a specific reason to reference an older version of tailwindcss on the CDN, please disregard this PR.

Otherwise, this pull request just bumps the version number in the CDN link up to `1.2`.