### PR TITLE
Use v1.2 color utilities in upgrade guide examples

### DIFF
--- a/source/docs/upgrading-to-v1.blade.md
+++ b/source/docs/upgrading-to-v1.blade.md
@@ -1002,7 +1002,7 @@ In v0.x, form elements used black text by default, even though true black was no
 In v1.0, form elements inherit their text color from the parent, which means if you have any markup like this:
 
 ```html
-<div class="text-red">
+<div class="text-red-700">
   <input type="text">
 </div>
 ```
@@ -1012,9 +1012,9 @@ In v1.0, form elements inherit their text color from the parent, which means if 
 You can fix this by setting a text color on form elements explicitly:
 
 ```diff
-  <div class="text-red">
+  <div class="text-red-700">
 -   <input type="text">
-+   <input type="text" class="text-grey-darkest">
++   <input type="text" class="text-gray-700">
   </div>
 ```
 


### PR DESCRIPTION
Hey Adam,

doing an upgrade I stumbled upon this. When upgrading to v1.2 I think the examples are supposed to use color utilities existing in v1.2 by default.

On the same note, I saw that the upgrade states `a { color: theme('colors.blue'); }` where `theme('colors.blue')` would return an object, I guess. But I first wanted to check in with you in case I am missing something here.

Thanks for very detailed upgrade guide! It's a pleasure to with! 

My best regards,
Micha
