### PR TITLE
fix tiny typo in docs

### DIFF
--- a/source/docs/pseudo-class-variants.blade.md
+++ b/source/docs/pseudo-class-variants.blade.md
@@ -564,7 +564,7 @@ Learn more about writing variant plugins in the [variant plugin documentation](/
 
 ## Default variants reference
 
-Due to file-size considerations, Tailwind does not all variants for all utilities by default.
+Due to file-size considerations, Tailwind does not include all variants for all utilities by default.
 
 To configure which variants are enabled for your project, see the [configuring variants documentation](/docs/configuring-variants).
 


### PR DESCRIPTION
"does not all variants for all utilities" -> "does not include all variants for all utilities"