### PR TITLE
Note inheritance limitation of text-opacity

### DIFF
--- a/source/docs/text-opacity.blade.md
+++ b/source/docs/text-opacity.blade.md
@@ -31,6 +31,8 @@ Control the opacity of an element's text color using the `.text-opacity-{amount}
 @endslot
 @endcomponent
 
+This utility works as a modifier to the `.text-{color}` utilities, and must be applied to the same element as the color utility to function. Inheritance of `.text-opacity-{amount}` to child `.text-{color}` elements and vice-versa is not supported.
+
 ## Responsive
 
 To control an element's text color opacity at a specific breakpoint, add a `{screen}:` prefix to any existing text color opacity utility. For example, use `md:text-opacity-50` to apply the `text-opacity-50` utility at only medium screen sizes and above.


### PR DESCRIPTION
Add a note to text-opacity docs mentioning inheritance limitation:

See: https://github.com/tailwindcss/tailwindcss/issues/1780