### PR TITLE
Fix license violation of user image

### DIFF
--- a/source/_assets/js/components/WorkflowAnimation.vue
+++ b/source/_assets/js/components/WorkflowAnimation.vue
@@ -226,7 +226,7 @@
    --></div>
       <div ref="card" class="shadow-lg leading-normal self-end bg-white w-64 rounded-lg -mt-16 relative" style="width: 20rem;">
         <div ref="cardLarge" class="hidden p-6">
-          <img ref="avatar" class="h-24 w-24 block mr-6 rounded-full" src="https://randomuser.me/api/portraits/women/17.jpg" alt="">
+          <img ref="avatar" class="h-24 w-24 block mr-6 rounded-full" src="https://images.unsplash.com/photo-1590955256762-e60f6e08122a?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&w=512&h=512&fit=crop&crop=focalpoint&fp-z=2&fp-y=0.25" alt="">
           <div ref="content" class="text-gray-800 text-left">
             <h2 ref="name" class="text-xl font-normal text-gray-800">
               <div class="inline-block relative">Erin Lindford</div>
@@ -243,7 +243,7 @@
           </div>
         </div>
         <div ref="cardSmall" class="hidden p-6">
-          <img ref="avatar" class="h-16 w-16 block mb-4 mx-auto rounded-full" src="https://randomuser.me/api/portraits/women/17.jpg" alt="">
+          <img ref="avatar" class="h-16 w-16 block mb-4 mx-auto rounded-full" src="https://images.unsplash.com/photo-1590955256762-e60f6e08122a?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&w=512&h=512&fit=crop&crop=focalpoint&fp-z=2&fp-y=0.25" alt="">
           <div ref="content" class="text-gray-800 text-center">
             <h2 ref="name" class="text-xl font-normal text-gray-800">
               <div class="inline-block relative">Erin Lindford</div>
@@ -260,7 +260,7 @@
           </div>
         </div>
         <div ref="cardInner">
-          <img ref="avatar" class="h-16 w-16 block mb-4" src="https://randomuser.me/api/portraits/women/17.jpg" alt="">
+          <img ref="avatar" class="h-16 w-16 block mb-4" src="https://images.unsplash.com/photo-1590955256762-e60f6e08122a?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&w=512&h=512&fit=crop&crop=focalpoint&fp-z=2&fp-y=0.25" alt="">
           <div ref="content" class="text-gray-800">
             <h2 ref="name" class="text-base font-normal text-gray-800">
               <div class="inline-block relative">Erin Lindford</div>

--- a/source/docs/utility-first.blade.md
+++ b/source/docs/utility-first.blade.md
@@ -139,7 +139,7 @@ This component is fully responsive and includes a button with hover styles, and 
 @component('_partials.code-sample', ['class' => 'p-8 bg-gray-200'])
 <div class="max-w-sm mx-auto bg-white shadow-lg rounded-lg overflow-hidden">
   <div class="sm:flex sm:items-center px-6 py-4">
-    <img class="block mx-auto sm:mx-0 sm:flex-shrink-0 h-16 sm:h-24 rounded-full" src="https://randomuser.me/api/portraits/women/17.jpg" alt="Woman's Face">
+    <img class="block mx-auto sm:mx-0 sm:flex-shrink-0 h-16 sm:h-24 rounded-full" src="https://images.unsplash.com/photo-1590955256762-e60f6e08122a?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&w=512&h=512&fit=crop&crop=focalpoint&fp-z=2&fp-y=0.25" alt="Woman's Face">
     <div class="mt-4 sm:mt-0 sm:ml-4 text-center sm:text-left">
       <p class="text-xl leading-tight">Erin Lindford</p>
       <p class="text-sm leading-tight text-gray-600">Customer Support Specialist</p>


### PR DESCRIPTION
The current image violates license because it should be used for internal design mockups only:

https://uifaces.co/license

Updated the image to be sourced from Unsplash, which has a more permissive license:
https://unsplash.com/license

The image is also higher resolution.

![Screen Shot 2020-06-28 at 2 38 32 PM](https://user-images.githubusercontent.com/4783091/85959112-2c98fc80-b94f-11ea-8186-ab60c024c1c9.png)
