### PR TITLE
Remove extra backtick

### DIFF
--- a/source/docs/theme.blade.md
+++ b/source/docs/theme.blade.md
@@ -408,7 +408,7 @@ All of these keys are also available under the `theme.extend` key to enable [ext
 | `gridRow` | Values for the `grid-row` property |
 | `gridRowStart` | Values for the `grid-row-start` property |
 | `gridRowEnd` | Values for the `grid-row-end` property |
-| `height`` | Values for the `height` property |
+| `height` | Values for the `height` property |
 | `inset` | Values for the `top`, `right`, `bottom`, and `left` properties |
 | `letterSpacing` | Values for the `letter-spacing` property |
 | `lineHeight` | Values for the `line-height` property |


### PR DESCRIPTION
Remove the extra backtick for fixing layout disorder.

Before:
![Screenshot 2020-07-21 at 4 47 30 PM](https://user-images.githubusercontent.com/8412286/88033634-2d9a0400-cb72-11ea-8083-f21fa6ebc794.png)

After:
![Screenshot 2020-07-21 at 4 47 42 PM](https://user-images.githubusercontent.com/8412286/88033673-38ed2f80-cb72-11ea-8c42-243a2778bc3e.png)
